### PR TITLE
DRY: Extract gate_cache_key into ftl2.types

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ftl2.state import State
 from ftl2.ftl_modules import list_modules, ExecuteResult
 from ftl2.inventory import Inventory, HostGroup, load_inventory, load_localhost
-from ftl2.types import HostConfig
+from ftl2.types import HostConfig, gate_cache_key
 from ftl2.ssh import SSHHost
 
 
@@ -960,7 +960,7 @@ class AutomationContext:
         from ftl2.message import GateProtocol
 
         become = host.become_config
-        cache_key = self._gate_cache_key(host.name, become)
+        cache_key = gate_cache_key(host.name, become)
 
         # Fast path: multiplexed gate — use msg_id future, no lock
         cached_gate = self._remote_runner.gate_cache.get(cache_key)
@@ -1231,13 +1231,6 @@ class AutomationContext:
 
         return result
 
-    @staticmethod
-    def _gate_cache_key(host_name: str, become: "BecomeConfig | None" = None) -> str:
-        """Build composite gate cache key including become config."""
-        if become and become.effective:
-            return f"{host_name}:become={become.become_user}:method={become.become_method}"
-        return host_name
-
     def _gate_lock(self, cache_key: str) -> asyncio.Lock:
         """Get or create a per-host lock for serializing gate access.
 
@@ -1282,7 +1275,7 @@ class AutomationContext:
         if self._remote_runner is None:
             raise RuntimeError("RemoteModuleRunner not initialized - use 'async with' context manager")
 
-        cache_key = self._gate_cache_key(host.name, become)
+        cache_key = gate_cache_key(host.name, become)
 
         # Fast path: multiplexed gate already in cache — no lock needed
         cached_gate = self._remote_runner.gate_cache.get(cache_key)
@@ -1602,7 +1595,7 @@ class AutomationContext:
             interpreter = host.ansible_python_interpreter or "/usr/bin/python3"
 
         # Check cache — verify interpreter matches
-        cache_key = self._gate_cache_key(host.name, become)
+        cache_key = gate_cache_key(host.name, become)
         if cache_key in self._remote_runner.gate_cache:
             gate = self._remote_runner.gate_cache[cache_key]
             if gate.interpreter == interpreter:

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -31,7 +31,7 @@ from .exceptions import (
 )
 from .gate import GateBuildConfig, GateBuilder
 from .message import GateProtocol
-from .types import BecomeConfig, ExecutionConfig, GateConfig, HostConfig, ModuleResult
+from .types import BecomeConfig, ExecutionConfig, GateConfig, HostConfig, ModuleResult, gate_cache_key
 from .utils import find_module, module_wants_json
 
 logger = logging.getLogger(__name__)
@@ -553,13 +553,6 @@ class RemoteModuleRunner(ModuleRunner):
         self.gate_builder: GateBuilder | None = None
         self.protocol = GateProtocol()
 
-    @staticmethod
-    def _gate_cache_key(host_name: str, become: "BecomeConfig | None" = None) -> str:
-        """Build composite gate cache key including become config."""
-        if become and become.effective:
-            return f"{host_name}:become={become.become_user}:method={become.become_method}"
-        return host_name
-
     async def run(
         self,
         host: HostConfig,
@@ -614,7 +607,7 @@ class RemoteModuleRunner(ModuleRunner):
 
         # Build composite cache key including become config
         become = host.become_config
-        cache_key = self._gate_cache_key(host.name, become)
+        cache_key = gate_cache_key(host.name, become)
 
         # Get or create gate connection
         gate = await self._get_or_create_gate(

--- a/src/ftl2/types.py
+++ b/src/ftl2/types.py
@@ -79,6 +79,13 @@ class BecomeConfig:
             raise ValueError(f"Unsupported become_method: {method!r}. Supported: sudo, su, doas")
 
 
+def gate_cache_key(host_name: str, become: "BecomeConfig | None" = None) -> str:
+    """Build composite gate cache key including become config."""
+    if become and become.effective:
+        return f"{host_name}:become={become.become_user}:method={become.become_method}"
+    return host_name
+
+
 @dataclass
 class HostConfig:
     """Configuration for a single host in the automation inventory.

--- a/tests/test_become.py
+++ b/tests/test_become.py
@@ -1,7 +1,7 @@
 """Tests for become privilege escalation support (sudo, su, doas)."""
 
 import pytest
-from ftl2.types import BecomeConfig, HostConfig
+from ftl2.types import BecomeConfig, HostConfig, gate_cache_key
 
 
 class TestBecomeConfig:
@@ -172,37 +172,22 @@ class TestExtractBecomeOverrides:
 
 
 class TestGateCacheKey:
-    """Tests for _gate_cache_key static method."""
+    """Tests for gate_cache_key function."""
 
     def test_no_become(self):
-        from ftl2.automation.context import AutomationContext
-
-        key = AutomationContext._gate_cache_key("web01")
-        assert key == "web01"
+        assert gate_cache_key("web01") == "web01"
 
     def test_become_none(self):
-        from ftl2.automation.context import AutomationContext
-
-        key = AutomationContext._gate_cache_key("web01", None)
-        assert key == "web01"
+        assert gate_cache_key("web01", None) == "web01"
 
     def test_become_disabled(self):
-        from ftl2.automation.context import AutomationContext
-
         bc = BecomeConfig(become=False)
-        key = AutomationContext._gate_cache_key("web01", bc)
-        assert key == "web01"
+        assert gate_cache_key("web01", bc) == "web01"
 
     def test_become_root(self):
-        from ftl2.automation.context import AutomationContext
-
         bc = BecomeConfig(become=True, become_user="root")
-        key = AutomationContext._gate_cache_key("web01", bc)
-        assert key == "web01:become=root:method=sudo"
+        assert gate_cache_key("web01", bc) == "web01:become=root:method=sudo"
 
     def test_become_user(self):
-        from ftl2.automation.context import AutomationContext
-
         bc = BecomeConfig(become=True, become_user="catbeez")
-        key = AutomationContext._gate_cache_key("web01", bc)
-        assert key == "web01:become=catbeez:method=sudo"
+        assert gate_cache_key("web01", bc) == "web01:become=catbeez:method=sudo"

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -1,7 +1,7 @@
 """Tests for gate multiplexing paths.
 
-Tests the Gate dataclass, _gate_reader_loop routing, cache key consistency
-between runners.py and context.py, and multiplexed message handling.
+Tests the Gate dataclass, _gate_reader_loop routing, cache key format,
+and multiplexed message handling.
 """
 
 import asyncio
@@ -9,10 +9,9 @@ import json
 
 import pytest
 
-from ftl2.runners import Gate, _gate_reader_loop, RemoteModuleRunner
-from ftl2.automation.context import AutomationContext
+from ftl2.runners import Gate, _gate_reader_loop
 from ftl2.message import GateProtocol
-from ftl2.types import BecomeConfig
+from ftl2.types import BecomeConfig, gate_cache_key
 
 
 # ---------------------------------------------------------------------------
@@ -225,57 +224,36 @@ class TestGateReaderLoop:
 # Cache key consistency
 # ---------------------------------------------------------------------------
 
-class TestCacheKeyConsistency:
-    """Verify runners.py and context.py produce identical cache keys."""
+class TestCacheKeyFormat:
+    """Verify gate_cache_key produces correct keys."""
 
     def test_no_become(self):
-        assert (
-            RemoteModuleRunner._gate_cache_key("web01")
-            == AutomationContext._gate_cache_key("web01")
-        )
+        assert gate_cache_key("web01") == "web01"
 
     def test_become_none(self):
-        assert (
-            RemoteModuleRunner._gate_cache_key("web01", None)
-            == AutomationContext._gate_cache_key("web01", None)
-        )
+        assert gate_cache_key("web01", None) == "web01"
 
     def test_become_disabled(self):
         bc = BecomeConfig(become=False)
-        assert (
-            RemoteModuleRunner._gate_cache_key("web01", bc)
-            == AutomationContext._gate_cache_key("web01", bc)
-        )
+        assert gate_cache_key("web01", bc) == "web01"
 
     def test_become_root_sudo(self):
         bc = BecomeConfig(become=True, become_user="root", become_method="sudo")
-        key_r = RemoteModuleRunner._gate_cache_key("web01", bc)
-        key_c = AutomationContext._gate_cache_key("web01", bc)
-        assert key_r == key_c
-        assert key_r == "web01:become=root:method=sudo"
+        assert gate_cache_key("web01", bc) == "web01:become=root:method=sudo"
 
     def test_become_deploy_doas(self):
         bc = BecomeConfig(become=True, become_user="deploy", become_method="doas")
-        key_r = RemoteModuleRunner._gate_cache_key("web01", bc)
-        key_c = AutomationContext._gate_cache_key("web01", bc)
-        assert key_r == key_c
-        assert key_r == "web01:become=deploy:method=doas"
+        assert gate_cache_key("web01", bc) == "web01:become=deploy:method=doas"
 
     def test_different_users_no_collision(self):
         bc1 = BecomeConfig(become=True, become_user="root")
         bc2 = BecomeConfig(become=True, become_user="deploy")
-        assert (
-            RemoteModuleRunner._gate_cache_key("web01", bc1)
-            != RemoteModuleRunner._gate_cache_key("web01", bc2)
-        )
+        assert gate_cache_key("web01", bc1) != gate_cache_key("web01", bc2)
 
     def test_different_methods_no_collision(self):
         bc_sudo = BecomeConfig(become=True, become_method="sudo")
         bc_doas = BecomeConfig(become=True, become_method="doas")
-        assert (
-            RemoteModuleRunner._gate_cache_key("web01", bc_sudo)
-            != RemoteModuleRunner._gate_cache_key("web01", bc_doas)
-        )
+        assert gate_cache_key("web01", bc_sudo) != gate_cache_key("web01", bc_doas)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract duplicated `_gate_cache_key` static method into a standalone `gate_cache_key()` function in `ftl2/types.py`
- Remove duplicate implementations from `RemoteModuleRunner` and `AutomationContext`
- Update all call sites and tests to use the shared function

## Test plan

- [x] All 1056 tests pass, no regressions
- [x] `TestGateCacheKey` in test_become.py updated to use shared function
- [x] `TestCacheKeyConsistency` replaced with `TestCacheKeyFormat` (no longer need consistency tests since there's only one implementation)

Fixes #11

Generated with [Claude Code](https://claude.com/claude-code)