### PR TITLE
Fix state-to-inventory round-trip

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -203,6 +203,115 @@ class TestStateClass:
             assert state2.get_host("web01")["ansible_host"] == "1.2.3.4"
 
 
+class TestStateToInventoryRoundTrip:
+    """Tests for state -> inventory YAML -> load_inventory round-trip."""
+
+    def test_single_group_round_trip(self):
+        """State with one group round-trips through YAML inventory."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "web01": {
+                    "ansible_host": "1.2.3.4",
+                    "ansible_user": "admin",
+                    "ansible_port": 22,
+                    "groups": ["webservers"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert "web01" in hosts
+        assert hosts["web01"].ansible_host == "1.2.3.4"
+        assert hosts["web01"].ansible_user == "admin"
+
+    def test_multiple_groups_round_trip(self):
+        """State with multiple groups round-trips through YAML inventory."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "web01": {
+                    "ansible_host": "1.2.3.4",
+                    "groups": ["webservers", "production"],
+                },
+                "db01": {
+                    "ansible_host": "1.2.3.5",
+                    "ansible_user": "dbadmin",
+                    "groups": ["databases"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert "web01" in hosts
+        assert "db01" in hosts
+        assert hosts["web01"].ansible_host == "1.2.3.4"
+        assert hosts["db01"].ansible_host == "1.2.3.5"
+        assert hosts["db01"].ansible_user == "dbadmin"
+
+        # Check groups exist
+        assert inventory.get_group("webservers") is not None
+        assert inventory.get_group("production") is not None
+        assert inventory.get_group("databases") is not None
+
+    def test_ungrouped_round_trip(self):
+        """State with no groups round-trips through YAML inventory."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "web01": {
+                    "ansible_host": "1.2.3.4",
+                    "ansible_port": 22,
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert "web01" in hosts
+        assert hosts["web01"].ansible_host == "1.2.3.4"
+
+    def test_empty_state_round_trip(self):
+        """Empty state produces valid YAML inventory."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+        from ftl2.inventory import load_inventory
+
+        yaml_out = state_to_inventory({"hosts": {}})
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name, require_hosts=False)
+
+        assert len(inventory.get_all_hosts()) == 0
+
+
 class TestMergeStateIntoInventory:
     """Tests for merging state hosts into inventory."""
 

--- a/tools/ftl2_state_to_inventory.py
+++ b/tools/ftl2_state_to_inventory.py
@@ -15,7 +15,11 @@ import sys
 
 
 def state_to_inventory(state: dict) -> str:
-    """Convert state dict to YAML inventory string."""
+    """Convert state dict to YAML inventory string.
+
+    Outputs groups at the top level (not nested under all.children)
+    so the result can be loaded by ftl2's inventory loader.
+    """
     hosts = state.get("hosts", {})
     if not hosts:
         return "all:\n  hosts: {}\n"
@@ -40,26 +44,14 @@ def state_to_inventory(state: dict) -> str:
         for group in host_groups:
             groups.setdefault(group, {})[host_name] = host_vars
 
-    # Build YAML
-    lines = ["all:"]
-
-    # If there's only one group, put hosts directly under all
-    if len(groups) == 1:
-        group_name, group_hosts = next(iter(groups.items()))
-        if group_name == "ungrouped":
-            lines.append("  hosts:")
-            for host_name, host_vars in sorted(group_hosts.items()):
-                _append_host(lines, host_name, host_vars, indent=4)
-            return "\n".join(lines) + "\n"
-
-    # Multiple groups or single named group — use children
-    lines.append("  children:")
+    # Build YAML with groups at the top level (compatible with ftl2 loader)
+    lines = []
     for group_name in sorted(groups):
         group_hosts = groups[group_name]
-        lines.append(f"    {group_name}:")
-        lines.append(f"      hosts:")
+        lines.append(f"{group_name}:")
+        lines.append(f"  hosts:")
         for host_name in sorted(group_hosts):
-            _append_host(lines, host_name, group_hosts[host_name], indent=8)
+            _append_host(lines, host_name, group_hosts[host_name], indent=4)
 
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
## Summary

- `state_to_inventory()` now outputs groups at the top level instead of nesting under `all.children`
- This makes the output compatible with `load_inventory()`, enabling the full provisioning cycle: provision hosts → persist state → reload inventory from state

## The Bug

`state_to_inventory` emitted:
```yaml
all:
  children:
    webservers:
      hosts:
        web01: {}
```

But `_load_inventory_yaml` expects groups at the top level (line 183: "Nested structure like 'all.children.webservers' is NOT supported").

## The Fix

Output flat top-level groups:
```yaml
webservers:
  hosts:
    web01: {}
```

## Test plan

- [x] 4 new round-trip tests (single group, multiple groups, ungrouped, empty)
- [x] All 1060 tests pass, no regressions

Fixes #6

Generated with [Claude Code](https://claude.com/claude-code)