### PR TITLE
Add strict mode for dependency resolution

### DIFF
--- a/src/ftl2/gate.py
+++ b/src/ftl2/gate.py
@@ -66,6 +66,7 @@ class GateBuildConfig:
     dependencies: list[str] = field(default_factory=list)
     interpreter: str = sys.executable
     local_interpreter: str = sys.executable
+    strict_dependencies: bool = False
 
     def __post_init__(self):
         """Convert string paths to Path objects."""
@@ -347,12 +348,20 @@ class GateBuilder:
             logger.debug(f"Installed module {module} to {target_path}")
 
             # Resolve dependencies
-            dep_result = find_all_dependencies(module_path)
+            dep_result = find_all_dependencies(
+                module_path, strict=config.strict_dependencies,
+            )
             for dep_path in dep_result.dependencies:
                 archive_path = get_archive_path(dep_path)
                 if archive_path not in all_deps:
                     all_deps[archive_path] = dep_path
 
+            if dep_result.unresolved:
+                names = [u.import_path for u in dep_result.unresolved]
+                logger.warning(
+                    f"Module {module}: {len(dep_result.unresolved)} unresolved "
+                    f"dependencies: {', '.join(names)}"
+                )
             logger.debug(
                 f"Module {module}: {len(dep_result.dependencies)} deps, "
                 f"{len(dep_result.unresolved)} unresolved"

--- a/src/ftl2/module_loading/dependencies.py
+++ b/src/ftl2/module_loading/dependencies.py
@@ -402,11 +402,21 @@ class DependencyResult:
         """Return number of resolved dependencies."""
         return len(self.dependencies)
 
+    def raise_if_unresolved(self) -> None:
+        """Raise RuntimeError if there are unresolved dependencies."""
+        if self.unresolved:
+            names = [u.import_path for u in self.unresolved]
+            raise RuntimeError(
+                f"Unresolved dependencies for {self.module_path.name}: "
+                f"{', '.join(names)}"
+            )
+
 
 def find_all_dependencies(
     module_path: Path,
     collection_paths: list[Path] | None = None,
     max_depth: int = 50,
+    strict: bool = False,
 ) -> DependencyResult:
     """Find all module_utils dependencies for a module (transitive).
 
@@ -417,9 +427,13 @@ def find_all_dependencies(
         module_path: Path to the module file
         collection_paths: Optional list of collection paths
         max_depth: Maximum recursion depth to prevent infinite loops
+        strict: If True, raise RuntimeError on unresolved dependencies
 
     Returns:
         DependencyResult with resolved and unresolved dependencies
+
+    Raises:
+        RuntimeError: If strict is True and there are unresolved dependencies
 
     Example:
         >>> result = find_all_dependencies(Path("/path/to/module.py"))
@@ -460,11 +474,14 @@ def find_all_dependencies(
 
             if dep_path is None:
                 result.unresolved.append(imp)
-                logger.debug(f"Could not resolve: {imp.import_path}")
+                logger.warning(f"Unresolved dependency: {imp.import_path}")
             elif dep_path not in seen_paths:
                 result.dependencies.append(dep_path)
                 # Queue for transitive dependency scanning
                 to_process.append((dep_path, depth + 1))
+
+    if strict:
+        result.raise_if_unresolved()
 
     return result
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from ftl2.module_loading.dependencies import (
+    DependencyResult,
     find_module_utils_imports,
     find_module_utils_imports_from_file,
     find_all_dependencies,
@@ -431,6 +432,44 @@ from ansible_collections.nonexistent.coll.plugins.module_utils.util import func
             assert len(result.dependencies) == 0
             assert len(result.unresolved) == 1
 
+    def test_strict_raises_on_unresolved(self):
+        """Test that strict=True raises RuntimeError on unresolved deps."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module = Path(tmpdir) / "module.py"
+            module.write_text("""
+from ansible_collections.nonexistent.coll.plugins.module_utils.util import func
+""")
+
+            with pytest.raises(RuntimeError, match="Unresolved dependencies"):
+                find_all_dependencies(module, [Path(tmpdir)], strict=True)
+
+    def test_strict_passes_when_all_resolved(self):
+        """Test that strict=True does not raise when all deps resolve."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+
+            module_utils_dir = (
+                base
+                / "ansible_collections"
+                / "testns"
+                / "testcoll"
+                / "plugins"
+                / "module_utils"
+            )
+            module_utils_dir.mkdir(parents=True)
+
+            module = base / "module.py"
+            module.write_text("""
+from ansible_collections.testns.testcoll.plugins.module_utils.helper import func
+""")
+
+            helper = module_utils_dir / "helper.py"
+            helper.write_text("def func(): pass")
+
+            # Should not raise
+            result = find_all_dependencies(module, [base], strict=True)
+            assert len(result.dependencies) == 1
+
     def test_dependency_result_iteration(self):
         """Test DependencyResult iteration."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -462,6 +501,24 @@ from ansible_collections.testns.testcoll.plugins.module_utils.util import func
 
             # Test len
             assert len(result) == 1
+
+
+class TestDependencyResult:
+    """Tests for DependencyResult dataclass."""
+
+    def test_raise_if_unresolved_with_unresolved(self):
+        """Test raise_if_unresolved raises when there are unresolved deps."""
+        result = DependencyResult(
+            module_path=Path("/fake/module.py"),
+            unresolved=[ModuleUtilsImport("ansible.module_utils.missing")],
+        )
+        with pytest.raises(RuntimeError, match="Unresolved dependencies.*missing"):
+            result.raise_if_unresolved()
+
+    def test_raise_if_unresolved_passes_when_empty(self):
+        """Test raise_if_unresolved does nothing when no unresolved deps."""
+        result = DependencyResult(module_path=Path("/fake/module.py"))
+        result.raise_if_unresolved()  # Should not raise
 
 
 class TestGetDependencyTree:


### PR DESCRIPTION
## Summary
- Add `strict` parameter to `find_all_dependencies()` that raises `RuntimeError` when dependencies cannot be resolved
- Add `raise_if_unresolved()` method to `DependencyResult` for explicit checking
- Add `strict_dependencies` field to `GateBuildConfig`, threaded through to gate building
- Upgrade unresolved dependency logging from debug to warning in both `dependencies.py` and `gate.py`

Fixes #5

## Test plan
- [x] New tests for strict mode raising on unresolved deps
- [x] New tests for strict mode passing when all deps resolve
- [x] New tests for `DependencyResult.raise_if_unresolved()`
- [x] Full test suite passes (1064 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)