### PR TITLE
Fix policy engine silent failure modes

### DIFF
--- a/src/ftl2/policy.py
+++ b/src/ftl2/policy.py
@@ -23,12 +23,16 @@ class PolicyDeniedError(Exception):
         self.rule = rule
 
 
+VALID_DECISIONS = frozenset({"allow", "deny"})
+VALID_MATCH_KEYS = frozenset({"module", "host", "environment"})
+
+
 @dataclass
 class PolicyRule:
     """A single policy rule.
 
     Attributes:
-        decision: "allow" or "deny"
+        decision: "deny" (only supported decision; "allow" is not implemented)
         match: Conditions to match against. Keys can be:
             - module: fnmatch pattern against module name
             - host: fnmatch pattern against target host
@@ -40,6 +44,21 @@ class PolicyRule:
     decision: str
     match: dict[str, str] = field(default_factory=dict)
     reason: str = ""
+
+    def __post_init__(self):
+        if self.decision not in VALID_DECISIONS:
+            raise ValueError(
+                f"Invalid decision {self.decision!r}; must be one of {sorted(VALID_DECISIONS)}"
+            )
+        if self.decision == "allow":
+            raise ValueError(
+                "allow rules are not supported; the policy engine uses a deny-list model"
+            )
+        for key in self.match:
+            if key not in VALID_MATCH_KEYS and not key.startswith("param."):
+                raise ValueError(
+                    f"Unknown match key {key!r}; must be one of {sorted(VALID_MATCH_KEYS)} or 'param.<name>'"
+                )
 
 
 @dataclass

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -30,14 +30,13 @@ class TestPolicyEvaluate:
         result = policy.evaluate("ping", {})
         assert result.permitted is True
 
-    def test_allow_rules_are_skipped(self):
-        rules = [
-            PolicyRule(decision="allow", match={"module": "shell"}),
-            PolicyRule(decision="deny", match={"module": "shell"}, reason="denied"),
-        ]
-        policy = Policy(rules)
-        result = policy.evaluate("shell", {})
-        assert result.permitted is False
+    def test_allow_rules_raise_error(self):
+        with pytest.raises(ValueError, match="allow rules are not supported"):
+            PolicyRule(decision="allow", match={"module": "shell"})
+
+    def test_invalid_decision_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid decision 'dennied'"):
+            PolicyRule(decision="dennied", match={"module": "shell"})
 
     def test_multiple_conditions_all_must_match(self):
         rule = PolicyRule(
@@ -81,11 +80,9 @@ class TestPolicyEvaluate:
         # Missing param -> empty string, no match
         assert policy.evaluate("file", {}).permitted is True
 
-    def test_unknown_condition_key_rejects_match(self):
-        rule = PolicyRule(decision="deny", match={"bogus_key": "val"}, reason="bad")
-        policy = Policy([rule])
-        # Unknown key causes rule to NOT match -> action permitted
-        assert policy.evaluate("shell", {}).permitted is True
+    def test_unknown_condition_key_raises_error(self):
+        with pytest.raises(ValueError, match="Unknown match key 'bogus_key'"):
+            PolicyRule(decision="deny", match={"bogus_key": "val"}, reason="bad")
 
     def test_first_matching_deny_wins(self):
         rules = [

--- a/tests/test_policy_validation.py
+++ b/tests/test_policy_validation.py
@@ -1,0 +1,65 @@
+"""Tests for policy engine validation (issue #21 - silent failure modes)."""
+
+import pytest
+
+from ftl2.policy import Policy, PolicyRule
+
+
+class TestDecisionValidation:
+    """Validate that invalid decision strings are rejected at construction."""
+
+    def test_typo_dennied_raises(self):
+        with pytest.raises(ValueError, match="Invalid decision 'dennied'"):
+            PolicyRule(decision="dennied", match={"module": "shell"})
+
+    def test_typo_dney_raises(self):
+        with pytest.raises(ValueError, match="Invalid decision 'dney'"):
+            PolicyRule(decision="dney", match={"module": "shell"})
+
+    def test_empty_decision_raises(self):
+        with pytest.raises(ValueError, match="Invalid decision ''"):
+            PolicyRule(decision="", match={"module": "shell"})
+
+    def test_allow_rejected_with_clear_message(self):
+        with pytest.raises(ValueError, match="allow rules are not supported"):
+            PolicyRule(decision="allow", match={"module": "shell"})
+
+    def test_deny_accepted(self):
+        rule = PolicyRule(decision="deny", match={"module": "shell"})
+        assert rule.decision == "deny"
+
+    def test_case_sensitive_deny(self):
+        """'Deny' (capitalized) should be rejected — only lowercase is valid."""
+        with pytest.raises(ValueError, match="Invalid decision 'Deny'"):
+            PolicyRule(decision="Deny", match={"module": "shell"})
+
+
+class TestMatchKeyValidation:
+    """Validate that unknown match keys are rejected at construction."""
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(ValueError, match="Unknown match key 'bogus'"):
+            PolicyRule(decision="deny", match={"bogus": "val"})
+
+    def test_param_dot_prefix_accepted(self):
+        rule = PolicyRule(decision="deny", match={"param.state": "absent"})
+        assert "param.state" in rule.match
+
+    def test_valid_keys_accepted(self):
+        rule = PolicyRule(
+            decision="deny",
+            match={"module": "shell", "host": "prod-*", "environment": "prod"},
+        )
+        assert len(rule.match) == 3
+
+
+class TestFromFileValidation:
+    """Validate that YAML files with bad rules fail on load."""
+
+    def test_yaml_with_typo_decision_fails(self, tmp_path):
+        policy_file = tmp_path / "bad.yaml"
+        policy_file.write_text(
+            "rules:\n  - decision: dennied\n    match:\n      module: shell\n"
+        )
+        with pytest.raises(ValueError, match="Invalid decision 'dennied'"):
+            Policy.from_file(policy_file)


### PR DESCRIPTION
## Summary

Fixes #21 — Policy engine silent failure modes.

Adds `__post_init__` validation to `PolicyRule` that catches all three silent failure modes at construction time:

- **Decision typos** (`"dennied"`) → `ValueError` with valid options
- **Allow rules** → `ValueError` explaining deny-list model
- **Unknown match keys** → `ValueError` with valid key list (supports `param.<name>`)

## Changes

- `src/ftl2/policy.py` — Added `VALID_DECISIONS`, `VALID_MATCH_KEYS` constants and `__post_init__` validation
- `tests/test_policy.py` — Updated 3 existing tests for new behavior
- `tests/test_policy_validation.py` — 10 new tests covering edge cases (typos, case sensitivity, empty strings, YAML integration)

## Review

Multi-model code review (Claude + Gemini): **PASS** — both models approve, consistent with ftl2-expert beliefs.

## Test plan

- [x] All 24 tests pass (14 existing + 10 new)
- [x] No regressions to existing deny-rule evaluation
- [x] Typos, empty strings, case variants all rejected
- [x] `from_file` propagates validation errors from YAML

🤖 Generated with [multiagent-loop](https://github.com/benthomasson/multiagent-loop)