### PR TITLE
Fix inventory fragility: cache removal, missing file errors

### DIFF
--- a/src/ftl2/automation/__init__.py
+++ b/src/ftl2/automation/__init__.py
@@ -77,6 +77,7 @@ async def automation(
     vault_secrets: dict[str, str] | None = None,
     policy: str | None = None,
     environment: str = "",
+    ignore_missing_inventory: bool = True,
 ) -> AsyncGenerator[AutomationContext, None]:
     """Create an automation context for running FTL modules.
 
@@ -265,6 +266,7 @@ async def automation(
         vault_secrets=vault_secrets,
         policy=policy,
         environment=environment,
+        ignore_missing_inventory=ignore_missing_inventory,
     )
 
     try:

--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -271,6 +271,7 @@ class AutomationContext:
         vault_secrets: dict[str, str] | None = None,
         policy: str | Path | None = None,
         environment: str = "",
+        ignore_missing_inventory: bool = False,
     ):
         """Initialize the automation context.
 
@@ -281,6 +282,8 @@ class AutomationContext:
                 - Inventory object directly
                 - Dict with inventory structure
                 - None for localhost-only execution
+            ignore_missing_inventory: If True, fall back to localhost when
+                inventory file is missing instead of raising.
             secrets: List of environment variable names to load as secrets.
                 Secrets are accessed via ftl.secrets["NAME"] and are never
                 logged or exposed in string representations.
@@ -351,7 +354,7 @@ class AutomationContext:
                 rules. Default is "" (empty string).
         """
         self._enabled_modules = modules
-        self._inventory = self._load_inventory(inventory)
+        self._inventory = self._load_inventory(inventory, ignore_missing=ignore_missing_inventory)
 
         # Initialize state if state_file provided
         self._state: "State | None" = None
@@ -512,12 +515,15 @@ class AutomationContext:
         return [r.error for r in self._results if not r.success and r.error]
 
     def _load_inventory(
-        self, inventory: str | Path | Inventory | dict[str, Any] | None
+        self,
+        inventory: str | Path | Inventory | dict[str, Any] | None,
+        ignore_missing: bool = False,
     ) -> Inventory:
         """Load inventory from various sources.
 
         Args:
             inventory: Inventory source
+            ignore_missing: If True, fall back to localhost when file is missing.
 
         Returns:
             Loaded Inventory object
@@ -533,9 +539,10 @@ class AutomationContext:
             path = Path(inventory)
             if path.exists():
                 return load_inventory(path, require_hosts=False)
-            else:
-                # File doesn't exist, return localhost
+            elif ignore_missing:
                 return load_localhost()
+            else:
+                raise FileNotFoundError(f"Inventory file not found: {path}")
 
         if isinstance(inventory, dict):
             # Build inventory from dict
@@ -657,9 +664,8 @@ class AutomationContext:
                 self._inventory.add_group(group)
             group.add_host(host)
 
-        # Invalidate caches so the new/updated host is visible
+        # Invalidate proxy so the new/updated host is visible
         self._hosts_proxy = None
-        self._inventory._invalidate_cache()
 
         # Persist to state file if enabled
         if self._state is not None:

--- a/src/ftl2/cli.py
+++ b/src/ftl2/cli.py
@@ -1928,7 +1928,6 @@ def run_module(
                         name: host for name, host in group.hosts.items()
                         if name in filtered
                     }
-                inv._invalidate_cache()
 
                 if output_format != "json" and limit:
                     click.echo(format_filter_summary(original_host_count, len(filtered), limit))
@@ -1962,7 +1961,6 @@ def run_module(
                             name: host for name, host in group.hosts.items()
                             if name in hosts_to_run
                         }
-                    inv._invalidate_cache()
 
                     logger.info(
                         f"Resume mode: running on {len(hosts_to_run)} hosts, "

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -72,12 +72,10 @@ class Inventory:
     """
 
     groups: dict[str, HostGroup] = field(default_factory=dict)
-    _all_hosts: dict[str, HostConfig] = field(default_factory=dict, init=False, repr=False)
 
     def add_group(self, group: HostGroup) -> None:
         """Add a group to the inventory."""
         self.groups[group.name] = group
-        self._invalidate_cache()
 
     def get_group(self, name: str) -> HostGroup | None:
         """Get a group by name."""
@@ -88,26 +86,13 @@ class Inventory:
         return list(self.groups.values())
 
     def get_all_hosts(self) -> dict[str, HostConfig]:
-        """Get all unique hosts across all groups.
-
-        Returns a dictionary mapping host names to HostConfig objects.
-        This is cached for performance.
-        """
-        if not self._all_hosts:
-            self._rebuild_hosts_cache()
-        return self._all_hosts
-
-    def _rebuild_hosts_cache(self) -> None:
-        """Rebuild the all_hosts cache."""
-        self._all_hosts = {}
+        """Get all unique hosts across all groups."""
+        result: dict[str, HostConfig] = {}
         for group in self.groups.values():
             for host_name, host in group.hosts.items():
-                if host_name not in self._all_hosts:
-                    self._all_hosts[host_name] = host
-
-    def _invalidate_cache(self) -> None:
-        """Invalidate the hosts cache."""
-        self._all_hosts = {}
+                if host_name not in result:
+                    result[host_name] = host
+        return result
 
 
 def load_inventory(inventory_file: str | Path, require_hosts: bool = True) -> Inventory:
@@ -136,6 +121,9 @@ def load_inventory(inventory_file: str | Path, require_hosts: bool = True) -> In
         >>> inventory = load_inventory("./ec2_inventory.py")
     """
     path = Path(inventory_file) if isinstance(inventory_file, str) else inventory_file
+
+    if not path.exists():
+        raise FileNotFoundError(f"Inventory file not found: {path}")
 
     # Executable script — run with --list
     if os.access(path, os.X_OK) and not path.suffix in (".yml", ".yaml", ".json"):

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -403,9 +403,15 @@ webservers:
             assert len(context.hosts["webservers"]) == 2
 
     @pytest.mark.asyncio
-    async def test_inventory_missing_file_falls_back_to_localhost(self):
-        """Test that missing inventory file falls back to localhost."""
-        context = AutomationContext(inventory="/nonexistent/path.yml")
+    async def test_inventory_missing_file_raises(self):
+        """Test that missing inventory file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            AutomationContext(inventory="/nonexistent/path.yml")
+
+    @pytest.mark.asyncio
+    async def test_inventory_missing_file_ignore_missing(self):
+        """Test that ignore_missing_inventory falls back to localhost."""
+        context = AutomationContext(inventory="/nonexistent/path.yml", ignore_missing_inventory=True)
         assert "localhost" in context.hosts
 
     @pytest.mark.asyncio

--- a/tests/test_issue22_inventory_fragility.py
+++ b/tests/test_issue22_inventory_fragility.py
@@ -1,0 +1,129 @@
+"""Tests for issue #22: Inventory fragility fixes.
+
+Tests three fixes:
+1. Cache invalidation gap — get_all_hosts() computes fresh every call
+2. Silent fallback on missing files — raises FileNotFoundError by default
+3. ignore_missing parameter — opt-in fallback to localhost
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ftl2.inventory import (
+    Inventory,
+    HostGroup,
+    load_inventory,
+    load_localhost,
+)
+from ftl2.types import HostConfig
+from ftl2 import AutomationContext
+
+
+class TestCacheInvalidationFix:
+    """Fix 1: Hosts added to groups after construction are immediately visible."""
+
+    def test_host_added_to_group_visible_in_get_all_hosts(self):
+        """Adding a host to a group after inventory construction should be
+        immediately visible via get_all_hosts() — the original bug."""
+        inv = Inventory()
+        group = HostGroup(name="web")
+        inv.add_group(group)
+
+        # get_all_hosts before adding any host
+        assert inv.get_all_hosts() == {}
+
+        # Mutate the group directly (the problematic pattern)
+        group.add_host(HostConfig(name="web01", ansible_host="10.0.0.1"))
+
+        # Should be immediately visible — no stale cache
+        all_hosts = inv.get_all_hosts()
+        assert "web01" in all_hosts
+        assert all_hosts["web01"].ansible_host == "10.0.0.1"
+
+    def test_multiple_groups_all_hosts_fresh(self):
+        """get_all_hosts() returns hosts from all groups, computed fresh."""
+        inv = Inventory()
+        g1 = HostGroup(name="web")
+        g2 = HostGroup(name="db")
+        g1.add_host(HostConfig(name="web01", ansible_host="10.0.0.1"))
+        inv.add_group(g1)
+        inv.add_group(g2)
+
+        assert len(inv.get_all_hosts()) == 1
+
+        # Add host to second group after construction
+        g2.add_host(HostConfig(name="db01", ansible_host="10.0.0.2"))
+        assert len(inv.get_all_hosts()) == 2
+        assert "db01" in inv.get_all_hosts()
+
+    def test_host_in_multiple_groups_deduplicated(self):
+        """Same host in two groups should appear once in get_all_hosts()."""
+        inv = Inventory()
+        host = HostConfig(name="shared", ansible_host="10.0.0.1")
+        g1 = HostGroup(name="web")
+        g2 = HostGroup(name="app")
+        g1.add_host(host)
+        g2.add_host(host)
+        inv.add_group(g1)
+        inv.add_group(g2)
+
+        assert len(inv.get_all_hosts()) == 1
+
+
+class TestMissingFileRaises:
+    """Fix 2: load_inventory() raises on missing files instead of silent fallback."""
+
+    def test_load_inventory_missing_file_raises(self):
+        """load_inventory() must raise FileNotFoundError for missing files."""
+        with pytest.raises(FileNotFoundError, match="Inventory file not found"):
+            load_inventory("/nonexistent/inventory.yml")
+
+    def test_load_inventory_missing_file_message_includes_path(self):
+        """Error message should include the missing path for debugging."""
+        path = "/tmp/does_not_exist_12345.yml"
+        with pytest.raises(FileNotFoundError, match=path):
+            load_inventory(path)
+
+    def test_load_inventory_existing_file_works(self):
+        """Existing inventory files should still load normally."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inv_file = Path(tmpdir) / "inventory.yml"
+            inv_file.write_text(
+                "web:\n  hosts:\n    web01:\n      ansible_host: 10.0.0.1\n"
+            )
+            inv = load_inventory(str(inv_file))
+            assert "web01" in inv.get_all_hosts()
+
+
+class TestContextMissingInventory:
+    """Fix 3: AutomationContext raises on missing inventory, with opt-in fallback."""
+
+    def test_context_missing_inventory_raises(self):
+        """AutomationContext should raise FileNotFoundError for missing inventory."""
+        with pytest.raises(FileNotFoundError):
+            AutomationContext(inventory="/nonexistent/path.yml")
+
+    def test_context_ignore_missing_falls_back_to_localhost(self):
+        """ignore_missing_inventory=True should fall back to localhost."""
+        ctx = AutomationContext(
+            inventory="/nonexistent/path.yml",
+            ignore_missing_inventory=True,
+        )
+        assert "localhost" in ctx.hosts
+
+    def test_context_none_inventory_still_gives_localhost(self):
+        """inventory=None should still default to localhost (unchanged behavior)."""
+        ctx = AutomationContext(inventory=None)
+        assert "localhost" in ctx.hosts
+
+    def test_context_existing_inventory_file_works(self):
+        """Existing inventory file should load normally."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inv_file = Path(tmpdir) / "inventory.yml"
+            inv_file.write_text(
+                "db:\n  hosts:\n    db01:\n      ansible_host: 10.0.0.2\n"
+            )
+            ctx = AutomationContext(inventory=str(inv_file))
+            assert "db01" in ctx.hosts


### PR DESCRIPTION
## Summary

Fixes #22 — Inventory fragility: cache invalidation gaps, silent fallback on missing files.

### Changes

1. **Remove `_all_hosts_cache`** — `get_all_hosts()` now computes fresh on every call, eliminating the cache invalidation bug where hosts added to groups post-construction were invisible
2. **Raise `FileNotFoundError` on missing inventory files** — instead of silently falling back to localhost, masking configuration mistakes
3. **Add `ignore_missing_inventory` parameter** — defaults to `True` on `automation()` for backward compat, `False` on `AutomationContext` for strict usage
4. **Remove 3 dangling `_invalidate_cache()` calls** — in `context.py` and `cli.py` (would have crashed with `AttributeError`)

### Files

- `src/ftl2/inventory.py` — Cache removal + missing file check
- `src/ftl2/automation/context.py` — `ignore_missing` parameter, remove cache call
- `src/ftl2/automation/__init__.py` — Expose `ignore_missing_inventory` on `automation()`
- `src/ftl2/cli.py` — Remove 2 dangling cache invalidation calls
- `tests/test_automation.py` — Updated for new behavior
- `tests/test_issue22_inventory_fragility.py` — 10 new tests

### Review

Multi-model code review (Claude + Gemini): Claude CONCERN (wrapper exposure, now addressed), Gemini PASS.

## Test plan

- [x] 10 new tests covering cache invalidation, missing files, opt-in fallback
- [x] Existing tests updated for new behavior
- [x] No dangling `_invalidate_cache()` references remain

🤖 Generated with [multiagent-loop](https://github.com/benthomasson/multiagent-loop)