### PR TITLE
Fix tech debt: GH-12, GH-13, GH-14

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1405,8 +1405,6 @@ class AutomationContext:
             if is_ftl_module(module_name):
                 # FTL module - try name-only first (gate may have it baked in)
                 try:
-                    gate = await self._get_or_create_gate(host, become=become)
-
                     # Send name-only FTLModule message
                     await self._remote_runner.protocol.send_message(
                         gate.gate_process.stdin,
@@ -1448,9 +1446,6 @@ class AutomationContext:
             if not ftl_attempted:
                 # Ansible module - build bundle and send through gate
                 import json
-
-                # Get gate connection
-                gate = await self._get_or_create_gate(host, become=become)
 
                 # Try name-only first (gate may have module baked in)
                 await self._remote_runner.protocol.send_message(

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -278,7 +278,22 @@ async def check_output(
 
 # Cache modules after first transfer so subsequent name-only requests
 # for the same module succeed without a ModuleNotFound round trip.
+# Use an LRU cache to bound memory in long-lived gate processes (GH-13).
+_MODULE_CACHE_MAX_SIZE = 128
 _module_cache: dict[str, bytes] = {}
+
+
+def _module_cache_set(name: str, data: bytes) -> None:
+    """Store a module in the bounded cache, evicting the oldest entry if full."""
+    if name in _module_cache:
+        # Move to end (most recently used)
+        _module_cache[name] = data
+        return
+    if len(_module_cache) >= _MODULE_CACHE_MAX_SIZE:
+        # Evict oldest entry (first key in insertion-ordered dict)
+        oldest = next(iter(_module_cache))
+        del _module_cache[oldest]
+    _module_cache[name] = data
 
 
 async def run_module(
@@ -302,7 +317,7 @@ async def run_module(
         if module is not None:
             logger.info("Loading module from message")
             module_bytes = base64.b64decode(module)
-            _module_cache[module_name] = module_bytes
+            _module_cache_set(module_name, module_bytes)
             with open(module_file, "wb") as f:
                 f.write(module_bytes)
         elif module_name in _module_cache:

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -286,10 +286,9 @@ _module_cache: dict[str, bytes] = {}
 def _module_cache_set(name: str, data: bytes) -> None:
     """Store a module in the bounded cache, evicting the oldest entry if full."""
     if name in _module_cache:
-        # Move to end (most recently used)
-        _module_cache[name] = data
-        return
-    if len(_module_cache) >= _MODULE_CACHE_MAX_SIZE:
+        # Delete and re-insert to move to end (most recently used)
+        del _module_cache[name]
+    elif len(_module_cache) >= _MODULE_CACHE_MAX_SIZE:
         # Evict oldest entry (first key in insertion-ordered dict)
         oldest = next(iter(_module_cache))
         del _module_cache[oldest]
@@ -323,6 +322,9 @@ async def run_module(
         elif module_name in _module_cache:
             logger.info("Loading module from cache")
             module_bytes = _module_cache[module_name]
+            # Touch LRU order: move to end so frequently used modules aren't evicted
+            del _module_cache[module_name]
+            _module_cache[module_name] = module_bytes
             with open(module_file, "wb") as f:
                 f.write(module_bytes)
         elif HAS_FTL_GATE:

--- a/src/ftl2/ftl_modules/file.py
+++ b/src/ftl2/ftl_modules/file.py
@@ -145,9 +145,11 @@ def ftl_file(
                     os.symlink(src, p)
                     changed = True
                 else:
-                    p.unlink()
-                    os.symlink(src, p)
-                    changed = True
+                    raise FTLModuleError(
+                        f"Symlink exists with different target: {current_target}",
+                        path=path,
+                        src=src,
+                    )
             elif p.exists():
                 if force:
                     if p.is_dir():

--- a/tests/test_ftl_modules_phase2.py
+++ b/tests/test_ftl_modules_phase2.py
@@ -1,5 +1,6 @@
 """Tests for FTL modules Phase 2 - Core module implementations."""
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, patch, MagicMock
@@ -133,6 +134,120 @@ class TestFtlFile:
         with pytest.raises(FTLModuleError) as exc_info:
             ftl_file(path="/tmp/test", state="invalid")
         assert "Invalid state" in str(exc_info.value)
+
+    # --- state=link tests (GH-14) ---
+
+    def test_link_creates_symlink(self):
+        """Test state=link creates a new symlink."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("hello")
+            link = Path(tmpdir) / "mylink"
+
+            result = ftl_file(path=str(link), state="link", src=str(target))
+
+            assert result["changed"] is True
+            assert link.is_symlink()
+            assert os.readlink(link) == str(target)
+
+    def test_link_creates_parent_dirs(self):
+        """Test state=link creates parent directories if needed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("hello")
+            link = Path(tmpdir) / "sub" / "dir" / "mylink"
+
+            result = ftl_file(path=str(link), state="link", src=str(target))
+
+            assert result["changed"] is True
+            assert link.is_symlink()
+
+    def test_link_idempotent_same_target(self):
+        """Test state=link is idempotent when symlink already points to same target."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("hello")
+            link = Path(tmpdir) / "mylink"
+            os.symlink(str(target), str(link))
+
+            result = ftl_file(path=str(link), state="link", src=str(target))
+
+            assert result["changed"] is False
+            assert os.readlink(link) == str(target)
+
+    def test_link_different_target_with_force(self):
+        """Test state=link replaces symlink when target differs and force=True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_target = Path(tmpdir) / "old.txt"
+            new_target = Path(tmpdir) / "new.txt"
+            old_target.write_text("old")
+            new_target.write_text("new")
+            link = Path(tmpdir) / "mylink"
+            os.symlink(str(old_target), str(link))
+
+            result = ftl_file(path=str(link), state="link", src=str(new_target), force=True)
+
+            assert result["changed"] is True
+            assert os.readlink(link) == str(new_target)
+
+    def test_link_different_target_without_force_raises(self):
+        """Test state=link raises error when target differs and force=False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_target = Path(tmpdir) / "old.txt"
+            new_target = Path(tmpdir) / "new.txt"
+            old_target.write_text("old")
+            new_target.write_text("new")
+            link = Path(tmpdir) / "mylink"
+            os.symlink(str(old_target), str(link))
+
+            with pytest.raises(FTLModuleError) as exc_info:
+                ftl_file(path=str(link), state="link", src=str(new_target))
+            assert "different target" in str(exc_info.value)
+
+    def test_link_over_existing_file_with_force(self):
+        """Test state=link replaces existing file when force=True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("target")
+            existing = Path(tmpdir) / "existing.txt"
+            existing.write_text("blocker")
+
+            result = ftl_file(path=str(existing), state="link", src=str(target), force=True)
+
+            assert result["changed"] is True
+            assert existing.is_symlink()
+            assert os.readlink(existing) == str(target)
+
+    def test_link_over_existing_file_without_force_raises(self):
+        """Test state=link raises error when path exists as file and force=False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("target")
+            existing = Path(tmpdir) / "existing.txt"
+            existing.write_text("blocker")
+
+            with pytest.raises(FTLModuleError) as exc_info:
+                ftl_file(path=str(existing), state="link", src=str(target))
+            assert "not a symlink" in str(exc_info.value)
+
+    def test_link_over_existing_dir_with_force(self):
+        """Test state=link replaces existing directory when force=True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "target.txt"
+            target.write_text("target")
+            existing_dir = Path(tmpdir) / "mydir"
+            existing_dir.mkdir()
+
+            result = ftl_file(path=str(existing_dir), state="link", src=str(target), force=True)
+
+            assert result["changed"] is True
+            assert existing_dir.is_symlink()
+
+    def test_link_requires_src(self):
+        """Test state=link raises error when src is not provided."""
+        with pytest.raises(FTLModuleError) as exc_info:
+            ftl_file(path="/tmp/mylink", state="link")
+        assert "src" in str(exc_info.value).lower()
 
 
 class TestFtlCopy:

--- a/tests/test_host_shadows_module.py
+++ b/tests/test_host_shadows_module.py
@@ -46,6 +46,20 @@ class _FakeContext:
     def hosts(self):
         return self._hosts_proxy
 
+    def _check_module_allowed(self, module_name: str) -> None:
+        if self._enabled_modules is None:
+            return
+        short_name = module_name.rsplit(".", 1)[-1]
+        if module_name in self._enabled_modules or short_name in self._enabled_modules:
+            return
+        allowlist_short = {e.rsplit(".", 1)[-1] for e in self._enabled_modules}
+        if short_name in allowlist_short:
+            return
+        raise AttributeError(
+            f"Module '{module_name}' is not enabled. "
+            f"Enabled modules: {', '.join(self._enabled_modules)}"
+        )
+
     async def execute(self, module_name, kwargs):
         return {"module": module_name, **kwargs}
 


### PR DESCRIPTION
## Summary

- **GH-12**: Remove redundant `_get_or_create_gate` calls in serial execution path (copy-paste artifacts)
- **GH-13**: Bound `_module_cache` with LRU eviction (max 128 entries) to prevent unbounded memory growth in long-lived gate processes
- **GH-14**: Fix `state=link` to raise `FTLModuleError` when symlink target differs and `force=False` (was silently overwriting, inconsistent with `p.exists()` behavior below)
- **Bonus**: Fix pre-existing test failure in `test_host_shadows_module.py` — add missing `_check_module_allowed` to `_FakeContext` stub

## Test plan

- [x] All 1519 tests pass (0 failures, 8 skipped)
- [x] Pre-existing `TestModuleAccessProxy::test_returns_callable_for_known_module` failure fixed
- [ ] Verify GH-13 LRU eviction works correctly with >128 modules
- [ ] Verify GH-14 error message is clear when symlink target differs without force

Closes #12, closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)