### PR TITLE
Add GateStatus self-reporting for gate health monitoring

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -5,6 +5,7 @@ ftl.module_name() syntax for automation scripts.
 """
 
 import asyncio
+import logging
 import os
 import time
 import warnings
@@ -21,6 +22,8 @@ from ftl2.ftl_modules import list_modules, ExecuteResult
 from ftl2.inventory import Inventory, HostGroup, load_inventory, load_localhost
 from ftl2.types import HostConfig, gate_cache_key
 from ftl2.ssh import SSHHost
+
+logger = logging.getLogger(__name__)
 
 
 class OutputMode(Enum):
@@ -1381,154 +1384,163 @@ class AutomationContext:
         if self._remote_runner is None:
             raise RuntimeError("RemoteModuleRunner not initialized - use 'async with' context manager")
 
-        cache_key = gate_cache_key(host.name, become)
+        try:
+            cache_key = gate_cache_key(host.name, become)
 
-        # Fast path: multiplexed gate already in cache — no lock needed
-        cached_gate = self._remote_runner.gate_cache.get(cache_key)
-        if cached_gate and cached_gate.multiplexed:
-            return await self._execute_multiplexed(cached_gate, host, module_name, params)
-
-        # Serial path: lock to prevent redundant SSH connections
-        async with self._gate_lock(cache_key):
-            # Re-check — another task may have created a multiplexed gate
+            # Fast path: multiplexed gate already in cache — no lock needed
             cached_gate = self._remote_runner.gate_cache.get(cache_key)
             if cached_gate and cached_gate.multiplexed:
                 return await self._execute_multiplexed(cached_gate, host, module_name, params)
 
-            # Create gate if needed — if it turns out multiplexed, use that path
-            gate = await self._get_or_create_gate(host, become=become)
-            if gate.multiplexed:
-                self._remote_runner.gate_cache[cache_key] = gate
-                return await self._execute_multiplexed(gate, host, module_name, params)
+            # Serial path: lock to prevent redundant SSH connections
+            async with self._gate_lock(cache_key):
+                # Re-check — another task may have created a multiplexed gate
+                cached_gate = self._remote_runner.gate_cache.get(cache_key)
+                if cached_gate and cached_gate.multiplexed:
+                    return await self._execute_multiplexed(cached_gate, host, module_name, params)
 
-            ftl_attempted = False
-            if is_ftl_module(module_name):
-                # FTL module - try name-only first (gate may have it baked in)
-                try:
-                    # Send name-only FTLModule message
-                    await self._remote_runner.protocol.send_message(
-                        gate.gate_process.stdin,
-                        "FTLModule",
-                        {
-                            "module_name": module_name,
-                            "module_args": params,
-                        },
-                    )
-                    response = await self._remote_runner.protocol.read_message(gate.gate_process.stdout)
-
-                    if response is not None and response[0] == "ModuleNotFound":
-                        # Not baked in — send source
-                        source = get_ftl_module_source(module_name)
-                        result_data = await self._remote_runner.run_ftl_module(
-                            gate, module_name, source, params
-                        )
-                    elif response is not None and response[0] == "FTLModuleResult":
-                        result_data = dict(response[1])
-                        # Gate wraps module output in {"result": ...} — unwrap it
-                        if "result" in result_data and isinstance(result_data["result"], dict):
-                            result_data = result_data["result"]
-                    elif response is not None and response[0] == "Error":
-                        raise Exception(response[1].get("message", "Unknown FTL module error"))
-                    else:
-                        raise Exception(f"Unexpected response: {response}")
-
-                    # Cache gate for reuse
+                # Create gate if needed — if it turns out multiplexed, use that path
+                gate = await self._get_or_create_gate(host, become=become)
+                if gate.multiplexed:
                     self._remote_runner.gate_cache[cache_key] = gate
-                    ftl_attempted = True
-                except Exception as e:
-                    # FTL module failed (missing deps, etc.) - fall back to Ansible bundle
-                    error_msg = str(e)
-                    if "No module named" in error_msg or "ImportError" in error_msg:
-                        ftl_attempted = False
-                    else:
-                        raise
+                    return await self._execute_multiplexed(gate, host, module_name, params)
 
-            if not ftl_attempted:
-                # Ansible module - build bundle and send through gate
-                import json
+                ftl_attempted = False
+                if is_ftl_module(module_name):
+                    # FTL module - try name-only first (gate may have it baked in)
+                    try:
+                        # Send name-only FTLModule message
+                        await self._remote_runner.protocol.send_message(
+                            gate.gate_process.stdin,
+                            "FTLModule",
+                            {
+                                "module_name": module_name,
+                                "module_args": params,
+                            },
+                        )
+                        response = await self._remote_runner.protocol.read_message(gate.gate_process.stdout)
 
-                # Try name-only first (gate may have module baked in)
-                await self._remote_runner.protocol.send_message(
-                    gate.gate_process.stdin,
-                    "Module",
-                    {
-                        "module_name": module_name,
-                        "module_args": params,
-                    },
-                )
+                        if response is not None and response[0] == "ModuleNotFound":
+                            # Not baked in — send source
+                            source = get_ftl_module_source(module_name)
+                            result_data = await self._remote_runner.run_ftl_module(
+                                gate, module_name, source, params
+                            )
+                        elif response is not None and response[0] == "FTLModuleResult":
+                            result_data = dict(response[1])
+                            # Gate wraps module output in {"result": ...} — unwrap it
+                            if "result" in result_data and isinstance(result_data["result"], dict):
+                                result_data = result_data["result"]
+                        elif response is not None and response[0] == "Error":
+                            result_data = {"failed": True, "msg": response[1].get("message", "Unknown FTL module error")}
+                        else:
+                            result_data = {"failed": True, "msg": f"Unexpected response: {response}"}
 
-                response = await self._remote_runner.protocol.read_message(gate.gate_process.stdout)
+                        # Cache gate for reuse
+                        self._remote_runner.gate_cache[cache_key] = gate
+                        ftl_attempted = True
+                    except Exception as e:
+                        # FTL module failed (missing deps, etc.) - fall back to Ansible bundle
+                        error_msg = str(e)
+                        if "No module named" in error_msg or "ImportError" in error_msg:
+                            ftl_attempted = False
+                        else:
+                            raise
 
-                if response is not None and response[0] == "ModuleNotFound":
-                    # Module not in gate — build bundle and retry
-                    import base64
+                if not ftl_attempted:
+                    # Ansible module - build bundle and send through gate
+                    import json
 
-                    if "." not in module_name:
-                        fqcn = f"ansible.builtin.{module_name}"
-                    else:
-                        fqcn = module_name
-
-                    bundle = self._bundle_cache.get_or_build(fqcn)
-                    bundle_b64 = base64.b64encode(bundle.data).decode()
+                    # Try name-only first (gate may have module baked in)
                     await self._remote_runner.protocol.send_message(
                         gate.gate_process.stdin,
                         "Module",
                         {
-                            "module": bundle_b64,
                             "module_name": module_name,
                             "module_args": params,
                         },
                     )
+
                     response = await self._remote_runner.protocol.read_message(gate.gate_process.stdout)
 
-                if response is None:
-                    result_data = {"failed": True, "msg": "No response from gate"}
-                else:
-                    msg_type, data = response
-                    if msg_type == "ModuleResult":
-                        # Parse the stdout as JSON (Ansible module output)
-                        stdout = data.get("stdout", "")
-                        stderr = data.get("stderr", "")
-                        try:
-                            result_data = json.loads(stdout) if stdout.strip() else {}
-                            if stderr:
-                                result_data["_stderr"] = stderr
-                            if not result_data:
+                    if response is not None and response[0] == "ModuleNotFound":
+                        # Module not in gate — build bundle and retry
+                        import base64
+
+                        if "." not in module_name:
+                            fqcn = f"ansible.builtin.{module_name}"
+                        else:
+                            fqcn = module_name
+
+                        bundle = self._bundle_cache.get_or_build(fqcn)
+                        bundle_b64 = base64.b64encode(bundle.data).decode()
+                        await self._remote_runner.protocol.send_message(
+                            gate.gate_process.stdin,
+                            "Module",
+                            {
+                                "module": bundle_b64,
+                                "module_name": module_name,
+                                "module_args": params,
+                            },
+                        )
+                        response = await self._remote_runner.protocol.read_message(gate.gate_process.stdout)
+
+                    if response is None:
+                        result_data = {"failed": True, "msg": "No response from gate"}
+                    else:
+                        msg_type, data = response
+                        if msg_type == "ModuleResult":
+                            # Parse the stdout as JSON (Ansible module output)
+                            stdout = data.get("stdout", "")
+                            stderr = data.get("stderr", "")
+                            try:
+                                result_data = json.loads(stdout) if stdout.strip() else {}
+                                if stderr:
+                                    result_data["_stderr"] = stderr
+                                if not result_data:
+                                    result_data = {
+                                        "failed": True,
+                                        "msg": f"Empty response from module. stderr: {stderr}",
+                                    }
+                                # Module crashed during import/execution — stderr has
+                                # a traceback but stdout has no failure indicator.
+                                if stderr and "Traceback" in stderr and not result_data.get("failed"):
+                                    result_data["failed"] = True
+                                    result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
+                            except json.JSONDecodeError as e:
                                 result_data = {
                                     "failed": True,
-                                    "msg": f"Empty response from module. stderr: {stderr}",
+                                    "msg": f"Invalid JSON response: {e}",
+                                    "stdout": stdout,
+                                    "stderr": stderr,
                                 }
-                            # Module crashed during import/execution — stderr has
-                            # a traceback but stdout has no failure indicator.
-                            if stderr and "Traceback" in stderr and not result_data.get("failed"):
-                                result_data["failed"] = True
-                                result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
-                        except json.JSONDecodeError as e:
-                            result_data = {
-                                "failed": True,
-                                "msg": f"Invalid JSON response: {e}",
-                                "stdout": stdout,
-                                "stderr": stderr,
-                            }
-                    elif msg_type == "Error":
-                        result_data = {"failed": True, "msg": data.get("message", "Unknown error")}
-                    else:
-                        result_data = {"failed": True, "msg": f"Unexpected response: {msg_type}"}
+                        elif msg_type == "Error":
+                            result_data = {"failed": True, "msg": data.get("message", "Unknown error")}
+                        else:
+                            result_data = {"failed": True, "msg": f"Unexpected response: {msg_type}"}
 
-                # Cache gate for reuse
-                self._remote_runner.gate_cache[cache_key] = gate
+                    # Cache gate for reuse
+                    self._remote_runner.gate_cache[cache_key] = gate
 
-        # Convert to ExecuteResult (outside lock — no gate access needed)
-        failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
-        return ExecuteResult(
-            success=not failed,
-            changed=result_data.get("changed", False),
-            output=result_data,
-            error=result_data.get("msg", "") if failed else "",
-            module=module_name,
-            host=host.name,
-            used_ftl=is_ftl_module(module_name),
-        )
+            # Convert to ExecuteResult (outside lock — no gate access needed)
+            failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
+            return ExecuteResult(
+                success=not failed,
+                changed=result_data.get("changed", False),
+                output=result_data,
+                error=result_data.get("msg", "") if failed else "",
+                module=module_name,
+                host=host.name,
+                used_ftl=is_ftl_module(module_name),
+            )
+
+        except Exception as e:
+            logger.exception(f"Remote execution failed for {module_name} on {host.name}")
+            return ExecuteResult.from_error(
+                f"Remote execution failed: {e}",
+                module=module_name,
+                host=host.name,
+            )
 
     async def _execute_multiplexed(
         self,
@@ -1546,118 +1558,127 @@ class AutomationContext:
         import base64
         import json
 
-        ftl_attempted = False
-        result_data: dict[str, Any] = {}
+        try:
+            ftl_attempted = False
+            result_data: dict[str, Any] = {}
 
-        if is_ftl_module(module_name):
-            try:
-                # Send name-only FTLModule request
+            if is_ftl_module(module_name):
+                try:
+                    # Send name-only FTLModule request
+                    msg_id = gate.next_msg_id()
+                    future = gate.create_future(msg_id)
+                    await self._remote_runner.protocol.send_message_with_id(
+                        gate.gate_process.stdin, "FTLModule",
+                        {"module_name": module_name, "module_args": params},
+                        msg_id, write_lock=gate._write_lock,
+                    )
+                    resp_type, resp_data = await future
+
+                    if resp_type == "ModuleNotFound":
+                        # Not baked in — send source with new msg_id
+                        source = get_ftl_module_source(module_name)
+                        module_b64 = base64.b64encode(source).decode()
+                        msg_id2 = gate.next_msg_id()
+                        future2 = gate.create_future(msg_id2)
+                        await self._remote_runner.protocol.send_message_with_id(
+                            gate.gate_process.stdin, "FTLModule",
+                            {"module_name": module_name, "module": module_b64, "module_args": params},
+                            msg_id2, write_lock=gate._write_lock,
+                        )
+                        resp_type, resp_data = await future2
+
+                    if resp_type == "FTLModuleResult":
+                        result_data = dict(resp_data)
+                        if "result" in result_data and isinstance(result_data["result"], dict):
+                            result_data = result_data["result"]
+                    elif resp_type == "Error":
+                        result_data = {"failed": True, "msg": resp_data.get("message", "Unknown FTL module error")}
+                    else:
+                        result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
+
+                    ftl_attempted = True
+                except Exception as e:
+                    error_msg = str(e)
+                    if "No module named" in error_msg or "ImportError" in error_msg:
+                        ftl_attempted = False
+                    else:
+                        raise
+
+            if not ftl_attempted:
+                # Ansible module — try name-only first
                 msg_id = gate.next_msg_id()
                 future = gate.create_future(msg_id)
                 await self._remote_runner.protocol.send_message_with_id(
-                    gate.gate_process.stdin, "FTLModule",
+                    gate.gate_process.stdin, "Module",
                     {"module_name": module_name, "module_args": params},
                     msg_id, write_lock=gate._write_lock,
                 )
                 resp_type, resp_data = await future
 
                 if resp_type == "ModuleNotFound":
-                    # Not baked in — send source with new msg_id
-                    source = get_ftl_module_source(module_name)
-                    module_b64 = base64.b64encode(source).decode()
+                    # Build bundle and retry
+                    if "." not in module_name:
+                        fqcn = f"ansible.builtin.{module_name}"
+                    else:
+                        fqcn = module_name
+
+                    bundle = self._bundle_cache.get_or_build(fqcn)
+                    bundle_b64 = base64.b64encode(bundle.data).decode()
+
                     msg_id2 = gate.next_msg_id()
                     future2 = gate.create_future(msg_id2)
                     await self._remote_runner.protocol.send_message_with_id(
-                        gate.gate_process.stdin, "FTLModule",
-                        {"module_name": module_name, "module": module_b64, "module_args": params},
+                        gate.gate_process.stdin, "Module",
+                        {"module": bundle_b64, "module_name": module_name, "module_args": params},
                         msg_id2, write_lock=gate._write_lock,
                     )
                     resp_type, resp_data = await future2
 
-                if resp_type == "FTLModuleResult":
-                    result_data = dict(resp_data)
-                    if "result" in result_data and isinstance(result_data["result"], dict):
-                        result_data = result_data["result"]
-                elif resp_type == "Error":
-                    raise Exception(resp_data.get("message", "Unknown FTL module error"))
-                else:
-                    raise Exception(f"Unexpected response: {resp_type}")
-
-                ftl_attempted = True
-            except Exception as e:
-                error_msg = str(e)
-                if "No module named" in error_msg or "ImportError" in error_msg:
-                    ftl_attempted = False
-                else:
-                    raise
-
-        if not ftl_attempted:
-            # Ansible module — try name-only first
-            msg_id = gate.next_msg_id()
-            future = gate.create_future(msg_id)
-            await self._remote_runner.protocol.send_message_with_id(
-                gate.gate_process.stdin, "Module",
-                {"module_name": module_name, "module_args": params},
-                msg_id, write_lock=gate._write_lock,
-            )
-            resp_type, resp_data = await future
-
-            if resp_type == "ModuleNotFound":
-                # Build bundle and retry
-                if "." not in module_name:
-                    fqcn = f"ansible.builtin.{module_name}"
-                else:
-                    fqcn = module_name
-
-                bundle = self._bundle_cache.get_or_build(fqcn)
-                bundle_b64 = base64.b64encode(bundle.data).decode()
-
-                msg_id2 = gate.next_msg_id()
-                future2 = gate.create_future(msg_id2)
-                await self._remote_runner.protocol.send_message_with_id(
-                    gate.gate_process.stdin, "Module",
-                    {"module": bundle_b64, "module_name": module_name, "module_args": params},
-                    msg_id2, write_lock=gate._write_lock,
-                )
-                resp_type, resp_data = await future2
-
-            if resp_type == "ModuleResult":
-                stdout = resp_data.get("stdout", "")
-                stderr = resp_data.get("stderr", "")
-                try:
-                    result_data = json.loads(stdout) if stdout.strip() else {}
-                    if stderr:
-                        result_data["_stderr"] = stderr
-                    if not result_data:
+                if resp_type == "ModuleResult":
+                    stdout = resp_data.get("stdout", "")
+                    stderr = resp_data.get("stderr", "")
+                    try:
+                        result_data = json.loads(stdout) if stdout.strip() else {}
+                        if stderr:
+                            result_data["_stderr"] = stderr
+                        if not result_data:
+                            result_data = {
+                                "failed": True,
+                                "msg": f"Empty response from module. stderr: {stderr}",
+                            }
+                        if stderr and "Traceback" in stderr and not result_data.get("failed"):
+                            result_data["failed"] = True
+                            result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
+                    except json.JSONDecodeError as e:
                         result_data = {
                             "failed": True,
-                            "msg": f"Empty response from module. stderr: {stderr}",
+                            "msg": f"Invalid JSON response: {e}",
+                            "stdout": stdout,
+                            "stderr": stderr,
                         }
-                    if stderr and "Traceback" in stderr and not result_data.get("failed"):
-                        result_data["failed"] = True
-                        result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
-                except json.JSONDecodeError as e:
-                    result_data = {
-                        "failed": True,
-                        "msg": f"Invalid JSON response: {e}",
-                        "stdout": stdout,
-                        "stderr": stderr,
-                    }
-            elif resp_type == "Error":
-                result_data = {"failed": True, "msg": resp_data.get("message", "Unknown error")}
-            else:
-                result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
+                elif resp_type == "Error":
+                    result_data = {"failed": True, "msg": resp_data.get("message", "Unknown error")}
+                else:
+                    result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
 
-        failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
-        return ExecuteResult(
-            success=not failed,
-            changed=result_data.get("changed", False),
-            output=result_data,
-            error=result_data.get("msg", "") if failed else "",
-            module=module_name,
-            host=host.name,
-            used_ftl=is_ftl_module(module_name),
-        )
+            failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
+            return ExecuteResult(
+                success=not failed,
+                changed=result_data.get("changed", False),
+                output=result_data,
+                error=result_data.get("msg", "") if failed else "",
+                module=module_name,
+                host=host.name,
+                used_ftl=is_ftl_module(module_name),
+            )
+
+        except Exception as e:
+            logger.exception(f"Multiplexed execution failed for {module_name} on {host.name}")
+            return ExecuteResult.from_error(
+                f"Remote execution failed: {e}",
+                module=module_name,
+                host=host.name,
+            )
 
     async def _get_or_create_gate(
         self,

--- a/src/ftl2/automation/proxy.py
+++ b/src/ftl2/automation/proxy.py
@@ -999,6 +999,72 @@ class HostScopedProxy:
         results = await asyncio.gather(*(_unmonitor_one(h) for h in host_configs))
         return results[0]
 
+    async def gate_status(self, interval: float = 5.0) -> dict[str, Any]:
+        """Start gate self-health streaming from the remote host.
+
+        Unlike ``monitor()`` (which requires psutil), gate status uses only
+        stdlib and always works — it's the most basic gate liveness signal.
+
+        Args:
+            interval: Seconds between status samples (default 5.0)
+
+        Returns:
+            dict with 'status' ("ok" or "error")
+
+        Example:
+            await ftl.webserver.gate_status(interval=5)
+            ftl.webserver.on("GateStatus", lambda s: print(s["state"]))
+            await ftl.listen(timeout=30)
+        """
+        host_configs = await self._get_host_configs()
+        if not host_configs:
+            raise ValueError(f"No hosts found for target: {self._target}")
+
+        async def _gate_status_one(host_config):
+            resp_type, resp_data = await self._context._send_gate_command(
+                host_config,
+                "StartGateStatus",
+                {"interval": interval},
+            )
+            if resp_type == "GateStatusResult":
+                if resp_data.get("status") == "error":
+                    raise RuntimeError(
+                        f"GateStatus failed on {host_config.name}: "
+                        f"{resp_data.get('message', 'unknown error')}"
+                    )
+                return resp_data
+            elif resp_type == "Error":
+                raise RuntimeError(resp_data.get("message", "GateStatus failed"))
+            else:
+                raise RuntimeError(f"Unexpected response to StartGateStatus: {resp_type}")
+
+        results = await asyncio.gather(*(_gate_status_one(h) for h in host_configs))
+        return results[0]
+
+    async def ungate_status(self) -> dict[str, Any]:
+        """Stop gate self-health streaming from the remote host.
+
+        Returns:
+            dict with 'status' ("stopped")
+        """
+        host_configs = await self._get_host_configs()
+        if not host_configs:
+            raise ValueError(f"No hosts found for target: {self._target}")
+
+        async def _ungate_status_one(host_config):
+            resp_type, resp_data = await self._context._send_gate_command(
+                host_config, "StopGateStatus", {}
+            )
+            if resp_type == "GateStatusResult":
+                return resp_data
+            elif resp_type == "Error":
+                raise RuntimeError(resp_data.get("message", "StopGateStatus failed"))
+            else:
+                raise RuntimeError(f"Unexpected response to StopGateStatus: {resp_type}")
+
+        results = await asyncio.gather(*(_ungate_status_one(h) for h in host_configs))
+        return results[0]
+
     def on(self, event_type: str, handler: Any) -> None:
         """Register an event handler for this host/group.
 

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -282,6 +282,13 @@ async def check_output(
 _MODULE_CACHE_MAX_SIZE = 128
 _module_cache: dict[str, bytes] = {}
 
+# Gate self-health state (updated at module execution entry/exit points)
+_gate_start_time: float = time.time()
+_gate_active_tasks: int = 0
+_gate_error_count: int = 0
+_gate_last_error: str | None = None
+_gate_current_tasks: set[str] = set()  # tracks all concurrently executing module names
+
 
 def _module_cache_set(name: str, data: bytes) -> None:
     """Store a module in the bounded cache, evicting the oldest entry if full."""
@@ -861,6 +868,135 @@ class SystemMonitor:
 
 
 # =============================================================================
+# Gate Status Reporter
+# =============================================================================
+
+
+class GateStatusReporter:
+    """Streams gate self-health metrics as GateStatus events.
+
+    Unlike SystemMonitor (which requires psutil), this uses only stdlib
+    (resource.getrusage + os.times) so it always works — it's the most
+    basic gate liveness signal.
+
+    Example:
+        reporter = GateStatusReporter(protocol, writer, gate_hash)
+        reporter.start(interval=5.0)
+        # ... later ...
+        reporter.stop()
+    """
+
+    def __init__(self, protocol: GateProtocol, writer: Any, gate_hash: str):
+        self._protocol = protocol
+        self._writer = writer
+        self._gate_hash = gate_hash
+        self._task: asyncio.Task | None = None
+        self._interval = 5.0
+        self._write_lock: asyncio.Lock | None = None
+        self._active_tasks_ref: set | None = None
+        self._prev_times = os.times()
+        self._prev_sample_time = time.time()
+
+    def start(self, interval: float = 5.0) -> None:
+        """Start the status reporting loop."""
+        if self._task is not None:
+            return
+        self._interval = interval
+        self._task = asyncio.create_task(self._status_loop())
+        logger.info(f"Gate status reporter started (interval={interval}s)")
+
+    async def _status_loop(self) -> None:
+        """Background task that samples gate status and emits GateStatus events."""
+        try:
+            while True:
+                await asyncio.sleep(self._interval)
+                status = self._collect_status()
+                try:
+                    if self._write_lock:
+                        async with self._write_lock:
+                            await self._protocol.send_message(
+                                self._writer, "GateStatus", status
+                            )
+                    else:
+                        await self._protocol.send_message(
+                            self._writer, "GateStatus", status
+                        )
+                except BrokenPipeError:
+                    return
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            logger.error(f"GateStatusReporter error: {e}")
+
+    def _collect_status(self) -> dict:
+        """Collect gate self-health metrics using only stdlib.
+
+        Note: ``memory_rss_peak`` reports peak (high-water-mark) RSS via
+        ``resource.getrusage(RUSAGE_SELF).ru_maxrss``, not current RSS.
+        Current RSS requires ``/proc/self/status`` (Linux) or ``psutil``.
+        """
+        import resource as _resource
+
+        hostname = os.uname().nodename
+        pid = os.getpid()
+        now = time.time()
+
+        # CPU: delta os.times() since last sample
+        times = os.times()
+        elapsed = now - self._prev_sample_time
+        if elapsed > 0:
+            user_delta = times.user - self._prev_times.user
+            sys_delta = times.system - self._prev_times.system
+            cpu_percent = round(((user_delta + sys_delta) / elapsed) * 100, 1)
+        else:
+            cpu_percent = 0.0
+        self._prev_times = times
+        self._prev_sample_time = now
+
+        # Memory RSS via resource module
+        rusage = _resource.getrusage(_resource.RUSAGE_SELF)
+        memory_rss = rusage.ru_maxrss
+        if sys.platform != "darwin":
+            memory_rss *= 1024  # Linux reports KB, macOS reports bytes
+
+        # Active channels from multiplexed tasks set
+        if self._active_tasks_ref is not None:
+            active_channels = len(self._active_tasks_ref)
+        else:
+            active_channels = 1 if _gate_active_tasks > 0 else 0
+
+        # State derived from counters
+        if _gate_active_tasks > 0:
+            state = "executing"
+        else:
+            state = "idle"
+
+        return {
+            "gate_id": f"{hostname}-{pid}",
+            "host": hostname,
+            "version": self._gate_hash,
+            "uptime_seconds": int(now - _gate_start_time),
+            "state": state,
+            "current_task": sorted(_gate_current_tasks) if _gate_current_tasks else None,
+            "cpu_percent": cpu_percent,
+            "memory_rss_peak": memory_rss,
+            "active_channels": active_channels,
+            "queue_depth": 0,
+            "error_count": _gate_error_count,
+            "last_error": _gate_last_error,
+            "module_cache_size": len(_module_cache),
+            "module_cache_bytes": sum(len(v) for v in _module_cache.values()),
+        }
+
+    def stop(self) -> None:
+        """Cancel the background task."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+            logger.info("Gate status reporter stopped")
+
+
+# =============================================================================
 # Main Entry Point
 # =============================================================================
 
@@ -915,9 +1051,10 @@ async def main(args: list[str]) -> int | None:
     # Initialize protocol
     protocol = GateProtocol()
 
-    # Initialize file watcher and system monitor (events are emitted concurrently)
+    # Initialize file watcher, system monitor, and gate status reporter
     watcher = FileWatcher(protocol, writer)
     monitor = SystemMonitor(protocol, writer)
+    status_reporter = GateStatusReporter(protocol, writer, gate_hash)
 
     # Message processing loop
     while True:
@@ -929,6 +1066,7 @@ async def main(args: list[str]) -> int | None:
                 logger.info("EOF received, shutting down")
                 watcher.stop()
                 monitor.stop()
+                status_reporter.stop()
                 try:
                     await protocol.send_message(writer, "Goodbye", {})
                 except Exception:
@@ -954,7 +1092,7 @@ async def main(args: list[str]) -> int | None:
                     else:
                         await protocol.send_message(writer, "Hello", response_data)
                     logger.info("Entering multiplexed mode")
-                    return await main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash)
+                    return await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, gate_hash)
                 else:
                     await protocol.send_message(writer, "Hello", response_data)
 
@@ -967,16 +1105,22 @@ async def main(args: list[str]) -> int | None:
                     )
                     continue
 
+                global _gate_active_tasks, _gate_error_count, _gate_last_error, _gate_current_tasks
+                _module_name = data.get("module_name", "")
+                _gate_active_tasks += 1
+                _gate_current_tasks.add(_module_name)
                 try:
                     await execute_module(
                         protocol,
                         writer,
-                        data.get("module_name", ""),
+                        _module_name,
                         data.get("module"),
                         data.get("module_args", {}),
                     )
 
                 except ModuleNotFoundError as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     await protocol.send_message(
                         writer,
                         "ModuleNotFound",
@@ -984,6 +1128,8 @@ async def main(args: list[str]) -> int | None:
                     )
 
                 except Exception as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     logger.exception("Module execution failed")
                     await protocol.send_message(
                         writer,
@@ -993,6 +1139,9 @@ async def main(args: list[str]) -> int | None:
                             "traceback": traceback.format_exc(),
                         },
                     )
+                finally:
+                    _gate_active_tasks -= 1
+                    _gate_current_tasks.discard(_module_name)
 
             elif msg_type == "FTLModule":
                 logger.info(f"FTLModule execution requested: {data.get('module_name', 'unknown')}")
@@ -1003,16 +1152,21 @@ async def main(args: list[str]) -> int | None:
                     )
                     continue
 
+                _module_name = data.get("module_name", "")
+                _gate_active_tasks += 1
+                _gate_current_tasks.add(_module_name)
                 try:
                     await execute_ftl_module(
                         protocol,
                         writer,
-                        data.get("module_name", ""),
+                        _module_name,
                         data.get("module", ""),
                         data.get("module_args", {}),
                     )
 
                 except ModuleNotFoundError as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     await protocol.send_message(
                         writer,
                         "ModuleNotFound",
@@ -1020,6 +1174,8 @@ async def main(args: list[str]) -> int | None:
                     )
 
                 except Exception as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     logger.exception("FTLModule execution failed")
                     await protocol.send_message(
                         writer,
@@ -1029,6 +1185,9 @@ async def main(args: list[str]) -> int | None:
                             "traceback": traceback.format_exc(),
                         },
                     )
+                finally:
+                    _gate_active_tasks -= 1
+                    _gate_current_tasks.discard(_module_name)
 
             elif msg_type == "Info":
                 logger.info("Info requested")
@@ -1119,10 +1278,26 @@ async def main(args: list[str]) -> int | None:
                     writer, "MonitorResult", {"status": "stopped"}
                 )
 
+            elif msg_type == "StartGateStatus":
+                interval = data.get("interval", 5.0) if isinstance(data, dict) else 5.0
+                logger.info(f"StartGateStatus requested (interval={interval}s)")
+                status_reporter.start(interval=interval)
+                await protocol.send_message(
+                    writer, "GateStatusResult", {"status": "ok"}
+                )
+
+            elif msg_type == "StopGateStatus":
+                logger.info("StopGateStatus requested")
+                status_reporter.stop()
+                await protocol.send_message(
+                    writer, "GateStatusResult", {"status": "stopped"}
+                )
+
             elif msg_type == "Shutdown":
                 logger.info("Shutdown requested")
                 watcher.stop()
                 monitor.stop()
+                status_reporter.stop()
                 await protocol.send_message(writer, "Goodbye", {})
                 return None
 
@@ -1160,7 +1335,7 @@ async def main(args: list[str]) -> int | None:
             return 1
 
 
-async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash):
+async def main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, gate_hash):
     """Concurrent message handling loop for multiplexed mode.
 
     Each incoming request is handled in its own asyncio task.
@@ -1173,6 +1348,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
     # messages don't interleave with request responses.
     watcher._write_lock = write_lock
     monitor._write_lock = write_lock
+    status_reporter._write_lock = write_lock
 
     async def handle_request(msg_type, data, msg_id):
         """Handle a single request and send response with same msg_id."""
@@ -1184,9 +1360,13 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                         msg_id, write_lock=write_lock,
                     )
                     return
+                global _gate_active_tasks, _gate_error_count, _gate_last_error, _gate_current_tasks
+                _module_name = data.get("module_name", "")
+                _gate_active_tasks += 1
+                _gate_current_tasks.add(_module_name)
                 try:
                     result = await run_module(
-                        data.get("module_name", ""),
+                        _module_name,
                         data.get("module"),
                         data.get("module_args", {}),
                     )
@@ -1195,11 +1375,16 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                         msg_id, write_lock=write_lock,
                     )
                 except ModuleNotFoundError as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     await protocol.send_message_with_id(
                         writer, "ModuleNotFound",
                         {"message": f"Module not found: {e}"},
                         msg_id, write_lock=write_lock,
                     )
+                finally:
+                    _gate_active_tasks -= 1
+                    _gate_current_tasks.discard(_module_name)
 
             elif msg_type == "FTLModule":
                 if not isinstance(data, dict):
@@ -1208,9 +1393,12 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                         msg_id, write_lock=write_lock,
                     )
                     return
+                _module_name = data.get("module_name", "")
+                _gate_active_tasks += 1
+                _gate_current_tasks.add(_module_name)
                 try:
                     resp_type, resp_data = await run_ftl_module(
-                        data.get("module_name", ""),
+                        _module_name,
                         data.get("module", ""),
                         data.get("module_args", {}),
                     )
@@ -1219,12 +1407,16 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                         msg_id, write_lock=write_lock,
                     )
                 except ModuleNotFoundError as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     await protocol.send_message_with_id(
                         writer, "ModuleNotFound",
                         {"message": f"FTLModule not found: {e}"},
                         msg_id, write_lock=write_lock,
                     )
                 except Exception as e:
+                    _gate_error_count += 1
+                    _gate_last_error = str(e)
                     logger.exception("FTLModule execution failed")
                     await protocol.send_message_with_id(
                         writer, "Error",
@@ -1234,6 +1426,9 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                         },
                         msg_id, write_lock=write_lock,
                     )
+                finally:
+                    _gate_active_tasks -= 1
+                    _gate_current_tasks.discard(_module_name)
 
             elif msg_type == "Info":
                 await protocol.send_message_with_id(
@@ -1317,6 +1512,21 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                     msg_id, write_lock=write_lock,
                 )
 
+            elif msg_type == "StartGateStatus":
+                interval = data.get("interval", 5.0) if isinstance(data, dict) else 5.0
+                status_reporter.start(interval=interval)
+                await protocol.send_message_with_id(
+                    writer, "GateStatusResult", {"status": "ok"},
+                    msg_id, write_lock=write_lock,
+                )
+
+            elif msg_type == "StopGateStatus":
+                status_reporter.stop()
+                await protocol.send_message_with_id(
+                    writer, "GateStatusResult", {"status": "stopped"},
+                    msg_id, write_lock=write_lock,
+                )
+
             else:
                 await protocol.send_message_with_id(
                     writer, "Error",
@@ -1339,6 +1549,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
 
     # Main reader loop
     tasks = set()
+    status_reporter._active_tasks_ref = tasks
     try:
         while True:
             msg = await protocol.read_message(reader)
@@ -1381,6 +1592,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
                 await asyncio.gather(*pending, return_exceptions=True)
         watcher.stop()
         monitor.stop()
+        status_reporter.stop()
 
     return None
 

--- a/src/ftl2/message.py
+++ b/src/ftl2/message.py
@@ -62,11 +62,16 @@ class GateProtocol:
         "StopMonitor",  # Stop system metrics streaming
         "MonitorResult",  # Response to Start/StopMonitor
         "SystemMetrics",  # Unsolicited system metrics event
+        "StartGateStatus",  # Start gate self-health streaming
+        "StopGateStatus",  # Stop gate self-health streaming
+        "GateStatusResult",  # Response to Start/StopGateStatus
+        "GateStatus",  # Unsolicited gate health event
     }
 
     EVENT_TYPES = {
         "FileChanged",
         "SystemMetrics",
+        "GateStatus",
     }
 
     async def send_message(

--- a/tests/test_context_error_handling.py
+++ b/tests/test_context_error_handling.py
@@ -1,0 +1,321 @@
+"""Tests for AutomationContext remote error handling (GH-75).
+
+Validates that _execute_remote_via_gate and _execute_multiplexed return
+ExecuteResult with success=False instead of raising exceptions, matching
+the errors-as-data contract.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+import pytest
+
+from ftl2.automation.context import AutomationContext
+from ftl2.exceptions import FTL2ConnectionError
+from ftl2.ftl_modules.executor import ExecuteResult
+from ftl2.message import GateProtocol, ProtocolError
+from ftl2.types import HostConfig, gate_cache_key
+
+
+def _make_context_with_mocks():
+    """Build an AutomationContext with a mocked remote runner."""
+    with patch.object(AutomationContext, '_check_name_collisions'):
+        ctx = AutomationContext()
+
+    # Create mocked remote runner
+    runner = MagicMock()
+    runner.gate_cache = {}
+    runner.protocol = GateProtocol()
+    ctx._remote_runner = runner
+    ctx._gate_locks = {}
+
+    return ctx
+
+
+def _make_host(name="web01"):
+    return HostConfig(name=name, ansible_host="192.168.1.10")
+
+
+class TestSerialPathErrorHandling:
+    """_execute_remote_via_gate returns ExecuteResult on failure."""
+
+    @pytest.mark.asyncio
+    async def test_gate_creation_failure_returns_result(self):
+        """SSH connection failure returns ExecuteResult, not exception."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        with patch.object(
+            ctx, '_get_or_create_gate',
+            side_effect=FTL2ConnectionError("SSH connection refused"),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "SSH connection refused" in result.error
+        assert result.module == "ping"
+        assert result.host == "web01"
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_returns_result(self):
+        """BrokenPipeError during send returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        # Mock gate creation to succeed
+        gate = MagicMock()
+        gate.multiplexed = False
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate.gate_process.stdout = MagicMock()
+
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate):
+            with patch.object(
+                ctx._remote_runner.protocol, 'send_message',
+                side_effect=BrokenPipeError("Connection lost"),
+            ):
+                result = await ctx._execute_remote_via_gate(host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Connection lost" in result.error
+
+    @pytest.mark.asyncio
+    async def test_protocol_error_returns_result(self):
+        """ProtocolError during read returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = False
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate.gate_process.stdout = MagicMock()
+
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate):
+            with patch.object(
+                ctx._remote_runner.protocol, 'send_message',
+                new_callable=AsyncMock,
+            ):
+                with patch.object(
+                    ctx._remote_runner.protocol, 'read_message',
+                    side_effect=ProtocolError("Invalid hex length"),
+                ):
+                    result = await ctx._execute_remote_via_gate(host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Invalid hex length" in result.error
+
+    @pytest.mark.asyncio
+    async def test_ftl_module_error_response_returns_result(self):
+        """Gate Error response for FTL module returns ExecuteResult, not exception."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = False
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate.gate_process.stdout = MagicMock()
+
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate):
+            with patch.object(
+                ctx._remote_runner.protocol, 'send_message',
+                new_callable=AsyncMock,
+            ):
+                with patch.object(
+                    ctx._remote_runner.protocol, 'read_message',
+                    new_callable=AsyncMock,
+                    return_value=("Error", {"message": "Module crashed"}),
+                ):
+                    with patch(
+                        'ftl2.ftl_modules.executor.is_ftl_module',
+                        return_value=True,
+                    ):
+                        result = await ctx._execute_remote_via_gate(
+                            host, "system_info", {},
+                        )
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Module crashed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_unexpected_response_returns_result(self):
+        """Unexpected gate response for FTL module returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = False
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate.gate_process.stdout = MagicMock()
+
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate):
+            with patch.object(
+                ctx._remote_runner.protocol, 'send_message',
+                new_callable=AsyncMock,
+            ):
+                with patch.object(
+                    ctx._remote_runner.protocol, 'read_message',
+                    new_callable=AsyncMock,
+                    return_value=("Bogus", {}),
+                ):
+                    with patch(
+                        'ftl2.ftl_modules.executor.is_ftl_module',
+                        return_value=True,
+                    ):
+                        result = await ctx._execute_remote_via_gate(
+                            host, "system_info", {},
+                        )
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Unexpected response" in result.error
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_still_raised(self):
+        """RuntimeError for uninitialized runner still raises (programming error)."""
+        with patch.object(AutomationContext, '_check_name_collisions'):
+            ctx = AutomationContext()
+        ctx._remote_runner = None
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await ctx._execute_remote_via_gate(_make_host(), "ping", {})
+
+    @pytest.mark.asyncio
+    async def test_output_dict_has_failed_key(self):
+        """ExecuteResult.output includes failed=True for structured error inspection."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        with patch.object(
+            ctx, '_get_or_create_gate',
+            side_effect=ConnectionError("timeout"),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "ping", {})
+
+        assert result.output.get("failed") is True
+        assert "msg" in result.output
+
+
+class TestMultiplexedPathErrorHandling:
+    """_execute_multiplexed returns ExecuteResult on failure."""
+
+    @pytest.mark.asyncio
+    async def test_protocol_error_returns_result(self):
+        """Protocol error in multiplexed path returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = True
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate._write_lock = asyncio.Lock()
+        gate.next_msg_id.return_value = 1
+
+        # Make create_future return a future that raises
+        future = asyncio.get_running_loop().create_future()
+        future.set_exception(ProtocolError("Connection dropped"))
+        gate.create_future.return_value = future
+
+        with patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id',
+            new_callable=AsyncMock,
+        ):
+            result = await ctx._execute_multiplexed(gate, host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Connection dropped" in result.error
+
+    @pytest.mark.asyncio
+    async def test_ftl_error_response_returns_result(self):
+        """Error response in multiplexed FTL path returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = True
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate._write_lock = asyncio.Lock()
+        gate.next_msg_id.return_value = 1
+
+        future = asyncio.get_running_loop().create_future()
+        future.set_result(("Error", {"message": "Import failed"}))
+        gate.create_future.return_value = future
+
+        with patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id',
+            new_callable=AsyncMock,
+        ):
+            with patch(
+                'ftl2.ftl_modules.executor.is_ftl_module',
+                return_value=True,
+            ):
+                result = await ctx._execute_multiplexed(
+                    gate, host, "system_info", {},
+                )
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Import failed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_broken_pipe_returns_result(self):
+        """BrokenPipeError in multiplexed path returns ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = MagicMock()
+        gate.multiplexed = True
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate._write_lock = asyncio.Lock()
+        gate.next_msg_id.return_value = 1
+        gate.create_future.return_value = asyncio.get_running_loop().create_future()
+
+        with patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id',
+            side_effect=BrokenPipeError("Pipe broken"),
+        ):
+            result = await ctx._execute_multiplexed(gate, host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert "Pipe broken" in result.error
+
+
+class TestErrorDataContract:
+    """Both paths honour the errors-as-data contract for all exception types."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc_class,exc_msg", [
+        (ConnectionError, "Connection refused"),
+        (OSError, "Network unreachable"),
+        (TimeoutError, "Operation timed out"),
+        (ProtocolError, "Invalid message format"),
+        (BrokenPipeError, "Broken pipe"),
+        (RuntimeError, "Gate process exited unexpectedly"),
+    ])
+    async def test_serial_path_catches_all(self, exc_class, exc_msg):
+        """Various exception types all produce ExecuteResult, never propagate."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        with patch.object(
+            ctx, '_get_or_create_gate',
+            side_effect=exc_class(exc_msg),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "ping", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert exc_msg in result.error
+        assert result.host == "web01"
+        assert result.module == "ping"

--- a/tests/test_gate_status.py
+++ b/tests/test_gate_status.py
@@ -1,0 +1,733 @@
+"""Tests for GateStatus self-reporting (Issue #67).
+
+Tests the GateStatusReporter class, message types, _collect_status schema,
+gate state tracking, and multiplexed/serial handler integration.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+from ftl2.message import GateProtocol
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reused from test_multiplexing.py pattern)
+# ---------------------------------------------------------------------------
+
+class MemoryWriter:
+    """Async writer that captures bytes in a buffer."""
+
+    def __init__(self):
+        self.buffer = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+
+class BrokenWriter:
+    """Writer that raises BrokenPipeError on write."""
+
+    def write(self, data: bytes) -> None:
+        raise BrokenPipeError("pipe closed")
+
+    async def drain(self) -> None:
+        pass
+
+
+def make_reader_from_messages(protocol_messages: list) -> asyncio.StreamReader:
+    """Build a StreamReader pre-loaded with length-prefixed JSON messages."""
+    buf = bytearray()
+    for msg in protocol_messages:
+        json_bytes = json.dumps(msg).encode("utf-8")
+        length_prefix = f"{len(json_bytes):08x}".encode("ascii")
+        buf.extend(length_prefix)
+        buf.extend(json_bytes)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(bytes(buf))
+    reader.feed_eof()
+    return reader
+
+
+def parse_responses(buf: bytearray) -> list:
+    """Parse length-prefixed JSON messages from a buffer."""
+    responses = []
+    pos = 0
+    while pos + 8 <= len(buf):
+        length = int(buf[pos:pos + 8].decode("ascii"), 16)
+        pos += 8
+        if pos + length > len(buf):
+            break
+        msg = json.loads(buf[pos:pos + length].decode("utf-8"))
+        responses.append(msg)
+        pos += length
+    return responses
+
+
+# ---------------------------------------------------------------------------
+# Message type registration
+# ---------------------------------------------------------------------------
+
+class TestGateStatusMessageTypes:
+    """Verify GateStatus message types are registered in the protocol."""
+
+    def test_start_gate_status_in_message_types(self):
+        assert "StartGateStatus" in GateProtocol.MESSAGE_TYPES
+
+    def test_stop_gate_status_in_message_types(self):
+        assert "StopGateStatus" in GateProtocol.MESSAGE_TYPES
+
+    def test_gate_status_result_in_message_types(self):
+        assert "GateStatusResult" in GateProtocol.MESSAGE_TYPES
+
+    def test_gate_status_in_message_types(self):
+        assert "GateStatus" in GateProtocol.MESSAGE_TYPES
+
+    def test_gate_status_in_event_types(self):
+        """GateStatus is an unsolicited push event, like SystemMetrics."""
+        assert "GateStatus" in GateProtocol.EVENT_TYPES
+
+    def test_gate_status_event_alongside_system_metrics(self):
+        """Both monitoring event types are registered."""
+        assert "SystemMetrics" in GateProtocol.EVENT_TYPES
+        assert "GateStatus" in GateProtocol.EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# GateStatusReporter unit tests
+# ---------------------------------------------------------------------------
+
+class TestGateStatusReporter:
+    """Tests for the GateStatusReporter class itself."""
+
+    def _make_reporter(self, writer=None, gate_hash="test-hash-123"):
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        if writer is None:
+            writer = MemoryWriter()
+        return GateStatusReporter(protocol, writer, gate_hash), writer
+
+    def test_init_defaults(self):
+        """Reporter initializes with correct defaults."""
+        reporter, _ = self._make_reporter()
+        assert reporter._task is None
+        assert reporter._interval == 5.0
+        assert reporter._write_lock is None
+        assert reporter._active_tasks_ref is None
+        assert reporter._gate_hash == "test-hash-123"
+
+    def test_collect_status_schema(self):
+        """_collect_status returns all required fields with correct types."""
+        reporter, _ = self._make_reporter(gate_hash="abc-def-789")
+        status = reporter._collect_status()
+
+        # All fields present
+        expected_keys = {
+            "gate_id", "host", "version", "uptime_seconds", "state",
+            "current_task", "cpu_percent", "memory_rss_peak",
+            "active_channels", "queue_depth", "error_count", "last_error",
+            "module_cache_size", "module_cache_bytes",
+        }
+        assert set(status.keys()) == expected_keys
+
+        # Type checks
+        assert isinstance(status["gate_id"], str)
+        assert isinstance(status["host"], str)
+        assert isinstance(status["version"], str)
+        assert isinstance(status["uptime_seconds"], int)
+        assert status["state"] in ("idle", "executing")
+        assert isinstance(status["cpu_percent"], float)
+        assert isinstance(status["memory_rss_peak"], int)
+        assert isinstance(status["active_channels"], int)
+        assert isinstance(status["queue_depth"], int)
+        assert isinstance(status["error_count"], int)
+        assert isinstance(status["module_cache_size"], int)
+        assert isinstance(status["module_cache_bytes"], int)
+
+    def test_collect_status_gate_id_format(self):
+        """gate_id is '{hostname}-{pid}'."""
+        reporter, _ = self._make_reporter()
+        status = reporter._collect_status()
+        expected_id = f"{os.uname().nodename}-{os.getpid()}"
+        assert status["gate_id"] == expected_id
+
+    def test_collect_status_version_is_gate_hash(self):
+        """version field reflects the gate_hash provided at construction."""
+        reporter, _ = self._make_reporter(gate_hash="my-version-42")
+        status = reporter._collect_status()
+        assert status["version"] == "my-version-42"
+
+    def test_collect_status_idle_state(self):
+        """State is 'idle' when no tasks are active."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved = gate_mod._gate_active_tasks
+        try:
+            gate_mod._gate_active_tasks = 0
+            reporter, _ = self._make_reporter()
+            status = reporter._collect_status()
+            assert status["state"] == "idle"
+            assert status["current_task"] is None
+        finally:
+            gate_mod._gate_active_tasks = saved
+
+    def test_collect_status_executing_state(self):
+        """State is 'executing' when tasks are active, current_task lists them."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_tasks = gate_mod._gate_active_tasks
+        saved_current = gate_mod._gate_current_tasks.copy()
+        try:
+            gate_mod._gate_active_tasks = 2
+            gate_mod._gate_current_tasks = {"dnf", "file"}
+            reporter, _ = self._make_reporter()
+            status = reporter._collect_status()
+            assert status["state"] == "executing"
+            assert status["current_task"] == ["dnf", "file"]  # sorted
+        finally:
+            gate_mod._gate_active_tasks = saved_tasks
+            gate_mod._gate_current_tasks = saved_current
+
+    def test_collect_status_error_tracking(self):
+        """Error count and last_error reflect gate state globals."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_count = gate_mod._gate_error_count
+        saved_last = gate_mod._gate_last_error
+        try:
+            gate_mod._gate_error_count = 7
+            gate_mod._gate_last_error = "module 'foo' not found"
+            reporter, _ = self._make_reporter()
+            status = reporter._collect_status()
+            assert status["error_count"] == 7
+            assert status["last_error"] == "module 'foo' not found"
+        finally:
+            gate_mod._gate_error_count = saved_count
+            gate_mod._gate_last_error = saved_last
+
+    def test_collect_status_module_cache(self):
+        """module_cache_size and module_cache_bytes reflect _module_cache."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_cache = gate_mod._module_cache.copy()
+        try:
+            gate_mod._module_cache = {
+                "ping": b"x" * 100,
+                "file": b"y" * 200,
+            }
+            reporter, _ = self._make_reporter()
+            status = reporter._collect_status()
+            assert status["module_cache_size"] == 2
+            assert status["module_cache_bytes"] == 300
+        finally:
+            gate_mod._module_cache = saved_cache
+
+    def test_collect_status_active_channels_serial_mode(self):
+        """Without active_tasks_ref, active_channels is 0 when idle, 1 when executing."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved = gate_mod._gate_active_tasks
+        try:
+            gate_mod._gate_active_tasks = 0
+            reporter, _ = self._make_reporter()
+            assert reporter._active_tasks_ref is None
+            status = reporter._collect_status()
+            assert status["active_channels"] == 0
+
+            gate_mod._gate_active_tasks = 1
+            status = reporter._collect_status()
+            assert status["active_channels"] == 1
+        finally:
+            gate_mod._gate_active_tasks = saved
+
+    def test_collect_status_active_channels_multiplexed_mode(self):
+        """With active_tasks_ref set, active_channels = len(tasks_set)."""
+        reporter, _ = self._make_reporter()
+        tasks = {"task_a", "task_b", "task_c"}
+        reporter._active_tasks_ref = tasks
+        status = reporter._collect_status()
+        assert status["active_channels"] == 3
+
+    def test_collect_status_queue_depth_always_zero(self):
+        """queue_depth is always 0 (no queuing in FTL2)."""
+        reporter, _ = self._make_reporter()
+        status = reporter._collect_status()
+        assert status["queue_depth"] == 0
+
+    def test_collect_status_uptime_positive(self):
+        """uptime_seconds is non-negative."""
+        reporter, _ = self._make_reporter()
+        status = reporter._collect_status()
+        assert status["uptime_seconds"] >= 0
+
+    def test_collect_status_memory_rss_peak_positive(self):
+        """memory_rss_peak is a positive integer (we're using memory)."""
+        reporter, _ = self._make_reporter()
+        status = reporter._collect_status()
+        assert status["memory_rss_peak"] > 0
+
+    def test_collect_status_cpu_percent_non_negative(self):
+        """cpu_percent is >= 0."""
+        reporter, _ = self._make_reporter()
+        status = reporter._collect_status()
+        assert status["cpu_percent"] >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        """Calling start() twice doesn't create a second background task."""
+        reporter, _ = self._make_reporter()
+        reporter.start(interval=100.0)  # Long interval so it doesn't fire
+        first_task = reporter._task
+        assert first_task is not None
+
+        reporter.start(interval=50.0)  # Should be a no-op
+        assert reporter._task is first_task  # Same task object
+
+        reporter.stop()
+
+    def test_stop_when_not_started(self):
+        """Calling stop() when not started is a no-op (no crash)."""
+        reporter, _ = self._make_reporter()
+        assert reporter._task is None
+        reporter.stop()  # Should not raise
+        assert reporter._task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self):
+        """stop() cancels the background task and sets it to None."""
+        reporter, _ = self._make_reporter()
+        reporter.start(interval=100.0)
+        assert reporter._task is not None
+        reporter.stop()
+        assert reporter._task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self):
+        """Calling stop() twice is safe."""
+        reporter, _ = self._make_reporter()
+        reporter.start(interval=100.0)
+        reporter.stop()
+        reporter.stop()  # Should not raise
+        assert reporter._task is None
+
+
+# ---------------------------------------------------------------------------
+# Status loop integration
+# ---------------------------------------------------------------------------
+
+class TestGateStatusLoop:
+    """Tests for the background _status_loop emitting GateStatus events."""
+
+    @pytest.mark.asyncio
+    async def test_status_loop_emits_event(self):
+        """The status loop emits a GateStatus event after one interval."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "loop-test")
+
+        reporter.start(interval=0.1)  # Short interval for testing
+        await asyncio.sleep(0.25)  # Wait for at least one emission
+        reporter.stop()
+
+        responses = parse_responses(writer.buffer)
+        gate_status_events = [r for r in responses if r[0] == "GateStatus"]
+        assert len(gate_status_events) >= 1, f"Expected GateStatus events, got: {responses}"
+
+        # Verify the emitted event has correct schema
+        event = gate_status_events[0]
+        status_data = event[1]
+        assert "gate_id" in status_data
+        assert "state" in status_data
+        assert status_data["version"] == "loop-test"
+
+    @pytest.mark.asyncio
+    async def test_status_loop_uses_write_lock(self):
+        """When _write_lock is set, the loop acquires it before writing."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "lock-test")
+
+        lock = asyncio.Lock()
+        reporter._write_lock = lock
+
+        reporter.start(interval=0.1)
+        await asyncio.sleep(0.25)
+        reporter.stop()
+
+        # If the lock was used correctly, we still get events
+        responses = parse_responses(writer.buffer)
+        gate_status_events = [r for r in responses if r[0] == "GateStatus"]
+        assert len(gate_status_events) >= 1
+
+    @pytest.mark.asyncio
+    async def test_status_loop_handles_broken_pipe(self):
+        """BrokenPipeError during write stops the loop gracefully."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = BrokenWriter()
+        reporter = GateStatusReporter(protocol, writer, "broken-test")
+
+        reporter.start(interval=0.05)
+        await asyncio.sleep(0.2)
+        # The loop should have exited due to BrokenPipeError, no crash
+        reporter.stop()
+
+    @pytest.mark.asyncio
+    async def test_status_loop_cancelled_on_stop(self):
+        """Stopping the reporter cancels the asyncio task cleanly."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "cancel-test")
+
+        reporter.start(interval=0.1)
+        task = reporter._task
+        assert not task.done()
+
+        reporter.stop()
+        # Give the event loop a chance to process the cancellation
+        await asyncio.sleep(0.05)
+        assert task.cancelled() or task.done()
+
+
+# ---------------------------------------------------------------------------
+# GateStatus event routing via _gate_reader_loop
+# ---------------------------------------------------------------------------
+
+class TestGateStatusEventRouting:
+    """Test that GateStatus events route correctly through the reader loop."""
+
+    @pytest.mark.asyncio
+    async def test_gate_status_routed_to_event_callback(self):
+        """GateStatus 2-tuple events are dispatched to the event callback."""
+        from ftl2.runners import Gate, _gate_reader_loop
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["GateStatus", {"gate_id": "host-1234", "state": "idle", "uptime_seconds": 60}],
+        ])
+
+        gate = Gate.__new__(Gate)
+        gate._pending = {}
+        gate.gate_process = type("P", (), {"stdout": reader})()
+
+        events = []
+
+        async def callback(event_type, data):
+            events.append((event_type, data))
+
+        await _gate_reader_loop(gate, protocol, event_callback=callback)
+
+        assert len(events) == 1
+        assert events[0][0] == "GateStatus"
+        assert events[0][1]["gate_id"] == "host-1234"
+        assert events[0][1]["state"] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_gate_status_dropped_without_callback(self):
+        """GateStatus events are silently dropped when no callback is set."""
+        from ftl2.runners import Gate, _gate_reader_loop
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["GateStatus", {"state": "idle"}],
+        ])
+
+        gate = Gate.__new__(Gate)
+        gate._pending = {}
+        gate.gate_process = type("P", (), {"stdout": reader})()
+
+        # Should complete without error
+        await _gate_reader_loop(gate, protocol, event_callback=None)
+
+
+# ---------------------------------------------------------------------------
+# Multiplexed mode integration
+# ---------------------------------------------------------------------------
+
+class TestGateStatusMultiplexed:
+    """Integration tests for GateStatus in multiplexed mode."""
+
+    @pytest.mark.asyncio
+    async def test_start_stop_lifecycle(self):
+        """StartGateStatus → GateStatusResult(ok), StopGateStatus → GateStatusResult(stopped)."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {"interval": 10.0}, 1],
+            ["StopGateStatus", {}, 2],
+            ["Shutdown", {}, 3],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "mux-test")
+
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "mux-test")
+
+        responses = parse_responses(writer.buffer)
+        by_id = {r[2]: r for r in responses if len(r) == 3}
+
+        assert by_id[1][0] == "GateStatusResult"
+        assert by_id[1][1]["status"] == "ok"
+        assert by_id[2][0] == "GateStatusResult"
+        assert by_id[2][1]["status"] == "stopped"
+        assert by_id[3][0] == "Goodbye"
+
+    @pytest.mark.asyncio
+    async def test_start_with_custom_interval(self):
+        """StartGateStatus accepts a custom interval."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {"interval": 30.0}, 10],
+            ["StopGateStatus", {}, 11],
+            ["Shutdown", {}, 12],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "interval-test")
+
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "interval-test")
+
+        responses = parse_responses(writer.buffer)
+        by_id = {r[2]: r for r in responses if len(r) == 3}
+        assert by_id[10][1]["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_start_without_interval_uses_default(self):
+        """StartGateStatus with empty data uses default 5.0s interval."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {}, 20],
+            ["StopGateStatus", {}, 21],
+            ["Shutdown", {}, 22],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "default-test")
+
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "default-test")
+
+        responses = parse_responses(writer.buffer)
+        by_id = {r[2]: r for r in responses if len(r) == 3}
+        assert by_id[20][0] == "GateStatusResult"
+        assert by_id[20][1]["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_stops_reporter(self):
+        """Shutdown cleans up the status reporter (via finally block)."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {"interval": 100.0}, 30],
+            ["Shutdown", {}, 31],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "shutdown-test")
+
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "shutdown-test")
+
+        # After shutdown, the reporter's task should be cleaned up
+        assert status_reporter._task is None
+
+    @pytest.mark.asyncio
+    async def test_gate_status_with_short_interval_emits_events(self):
+        """With a short interval, GateStatus events appear in the output alongside responses."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+
+        # Build messages manually with a delay mechanism:
+        # Start with a short interval, then wait via slow reader, then stop+shutdown
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {"interval": 0.1}, 40],
+            ["StopGateStatus", {}, 41],
+            ["Shutdown", {}, 42],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "emit-test")
+
+        # We need to give the reporter time to emit. Use a wrapper reader
+        # that delays before the StopGateStatus message.
+        original_reader = reader
+
+        # Create a reader with built-in delay
+        delayed_buf = bytearray()
+        msgs = [
+            ["StartGateStatus", {"interval": 0.1}, 40],
+        ]
+        for msg in msgs:
+            json_bytes = json.dumps(msg).encode("utf-8")
+            length_prefix = f"{len(json_bytes):08x}".encode("ascii")
+            delayed_buf.extend(length_prefix)
+            delayed_buf.extend(json_bytes)
+
+        delayed_reader = asyncio.StreamReader()
+        delayed_reader.feed_data(bytes(delayed_buf))
+
+        # Feed the rest after a delay
+        async def feed_rest():
+            await asyncio.sleep(0.35)  # Let 2-3 status events emit
+            rest_msgs = [
+                ["StopGateStatus", {}, 41],
+                ["Shutdown", {}, 42],
+            ]
+            rest_buf = bytearray()
+            for msg in rest_msgs:
+                json_bytes = json.dumps(msg).encode("utf-8")
+                length_prefix = f"{len(json_bytes):08x}".encode("ascii")
+                rest_buf.extend(length_prefix)
+                rest_buf.extend(json_bytes)
+            delayed_reader.feed_data(bytes(rest_buf))
+            delayed_reader.feed_eof()
+
+        feeder_task = asyncio.create_task(feed_rest())
+
+        await main_multiplexed(
+            delayed_reader, writer, protocol, watcher, monitor, status_reporter, "emit-test"
+        )
+        await feeder_task
+
+        responses = parse_responses(writer.buffer)
+        gate_status_events = [r for r in responses if r[0] == "GateStatus"]
+        assert len(gate_status_events) >= 1, (
+            f"Expected at least one GateStatus event, got: {[r[0] for r in responses]}"
+        )
+
+        # Verify the event schema
+        event_data = gate_status_events[0][1]
+        assert event_data["version"] == "emit-test"
+        assert "state" in event_data
+        assert "gate_id" in event_data
+
+
+# ---------------------------------------------------------------------------
+# Edge cases from reviewer notes
+# ---------------------------------------------------------------------------
+
+class TestGateStatusEdgeCases:
+    """Edge cases identified during code review."""
+
+    def test_current_task_returns_sorted_list(self):
+        """When multiple tasks execute, current_task is a sorted list."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_tasks = gate_mod._gate_active_tasks
+        saved_current = gate_mod._gate_current_tasks.copy()
+        try:
+            gate_mod._gate_active_tasks = 3
+            gate_mod._gate_current_tasks = {"zzz_module", "aaa_module", "mmm_module"}
+
+            from ftl2.ftl_gate.__main__ import GateStatusReporter
+            protocol = GateProtocol()
+            writer = MemoryWriter()
+            reporter = GateStatusReporter(protocol, writer, "sort-test")
+            status = reporter._collect_status()
+
+            assert status["current_task"] == ["aaa_module", "mmm_module", "zzz_module"]
+        finally:
+            gate_mod._gate_active_tasks = saved_tasks
+            gate_mod._gate_current_tasks = saved_current
+
+    def test_collect_status_with_empty_cache(self):
+        """module_cache_size=0 and module_cache_bytes=0 when cache is empty."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_cache = gate_mod._module_cache.copy()
+        try:
+            gate_mod._module_cache = {}
+            from ftl2.ftl_gate.__main__ import GateStatusReporter
+            protocol = GateProtocol()
+            writer = MemoryWriter()
+            reporter = GateStatusReporter(protocol, writer, "cache-test")
+            status = reporter._collect_status()
+            assert status["module_cache_size"] == 0
+            assert status["module_cache_bytes"] == 0
+        finally:
+            gate_mod._module_cache = saved_cache
+
+    def test_collect_status_host_matches_uname(self):
+        """host field matches os.uname().nodename."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "host-test")
+        status = reporter._collect_status()
+        assert status["host"] == os.uname().nodename
+
+    def test_memory_rss_peak_platform_handling(self):
+        """memory_rss_peak uses correct units per platform."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        import resource as _resource
+
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "mem-test")
+        status = reporter._collect_status()
+
+        rusage = _resource.getrusage(_resource.RUSAGE_SELF)
+        if sys.platform == "darwin":
+            # macOS: ru_maxrss is in bytes
+            assert status["memory_rss_peak"] == rusage.ru_maxrss
+        else:
+            # Linux: ru_maxrss is in KB, multiplied by 1024
+            assert status["memory_rss_peak"] == rusage.ru_maxrss * 1024
+
+    def test_cpu_percent_handles_zero_elapsed(self):
+        """CPU percent doesn't divide by zero on rapid successive calls."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "cpu-test")
+
+        # Force _prev_sample_time to now so elapsed ≈ 0
+        reporter._prev_sample_time = time.time()
+        reporter._prev_times = os.times()
+        status = reporter._collect_status()
+        assert status["cpu_percent"] >= 0.0  # Should not raise
+
+    def test_no_errors_initially(self):
+        """Fresh gate state has 0 errors and None last_error."""
+        import ftl2.ftl_gate.__main__ as gate_mod
+        saved_count = gate_mod._gate_error_count
+        saved_last = gate_mod._gate_last_error
+        try:
+            gate_mod._gate_error_count = 0
+            gate_mod._gate_last_error = None
+
+            from ftl2.ftl_gate.__main__ import GateStatusReporter
+            protocol = GateProtocol()
+            writer = MemoryWriter()
+            reporter = GateStatusReporter(protocol, writer, "fresh-test")
+            status = reporter._collect_status()
+            assert status["error_count"] == 0
+            assert status["last_error"] is None
+        finally:
+            gate_mod._gate_error_count = saved_count
+            gate_mod._gate_last_error = saved_last
+
+    def test_collect_status_is_json_serializable(self):
+        """The status dict must be JSON-serializable for the wire protocol."""
+        from ftl2.ftl_gate.__main__ import GateStatusReporter
+        protocol = GateProtocol()
+        writer = MemoryWriter()
+        reporter = GateStatusReporter(protocol, writer, "json-test")
+        status = reporter._collect_status()
+        # Should not raise
+        serialized = json.dumps(status)
+        deserialized = json.loads(serialized)
+        assert deserialized == status

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -266,7 +266,7 @@ class TestMainMultiplexed:
     @pytest.mark.asyncio
     async def test_shutdown_sends_goodbye(self):
         """Shutdown message gets a Goodbye response."""
-        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
 
         protocol = GateProtocol()
         reader = make_reader_from_messages([
@@ -275,8 +275,9 @@ class TestMainMultiplexed:
         writer = MemoryWriter()
         watcher = FileWatcher(protocol, writer)
         monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "abc123")
 
-        result = await main_multiplexed(reader, writer, protocol, watcher, monitor, "abc123")
+        result = await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "abc123")
 
         assert result is None
         # Parse the response from writer buffer
@@ -287,7 +288,7 @@ class TestMainMultiplexed:
     @pytest.mark.asyncio
     async def test_module_execution(self):
         """Module request gets a response with the correct msg_id."""
-        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
 
         protocol = GateProtocol()
         # Send a Module request for a module that won't be found (no gate bundle)
@@ -299,8 +300,9 @@ class TestMainMultiplexed:
         writer = MemoryWriter()
         watcher = FileWatcher(protocol, writer)
         monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "abc123")
 
-        await main_multiplexed(reader, writer, protocol, watcher, monitor, "abc123")
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "abc123")
 
         # Parse all responses from writer buffer
         responses = self._parse_responses(writer.buffer)
@@ -316,7 +318,7 @@ class TestMainMultiplexed:
     @pytest.mark.asyncio
     async def test_info_request(self):
         """Info request returns gate info with correct msg_id."""
-        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
 
         protocol = GateProtocol()
         reader = make_reader_from_messages([
@@ -326,14 +328,50 @@ class TestMainMultiplexed:
         writer = MemoryWriter()
         watcher = FileWatcher(protocol, writer)
         monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "abc123")
 
-        await main_multiplexed(reader, writer, protocol, watcher, monitor, "abc123")
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "abc123")
 
         responses = self._parse_responses(writer.buffer)
         info_resp = [r for r in responses if r[0] == "InfoResult"]
         assert len(info_resp) == 1
         assert info_resp[0][2] == 10
         assert "python_version" in info_resp[0][1]
+
+    @pytest.mark.asyncio
+    async def test_gate_status_start_stop(self):
+        """StartGateStatus and StopGateStatus get GateStatusResult responses."""
+        from ftl2.ftl_gate.__main__ import main_multiplexed, FileWatcher, SystemMonitor, GateStatusReporter
+
+        protocol = GateProtocol()
+        reader = make_reader_from_messages([
+            ["StartGateStatus", {"interval": 10.0}, 20],
+            ["StopGateStatus", {}, 21],
+            ["Shutdown", {}, 22],
+        ])
+        writer = MemoryWriter()
+        watcher = FileWatcher(protocol, writer)
+        monitor = SystemMonitor(protocol, writer)
+        status_reporter = GateStatusReporter(protocol, writer, "abc123")
+
+        await main_multiplexed(reader, writer, protocol, watcher, monitor, status_reporter, "abc123")
+
+        responses = self._parse_responses(writer.buffer)
+        by_id = {r[2]: r for r in responses if len(r) == 3}
+
+        # StartGateStatus should return ok
+        assert 20 in by_id, f"No response for msg_id=20 in {responses}"
+        assert by_id[20][0] == "GateStatusResult"
+        assert by_id[20][1]["status"] == "ok"
+
+        # StopGateStatus should return stopped
+        assert 21 in by_id, f"No response for msg_id=21 in {responses}"
+        assert by_id[21][0] == "GateStatusResult"
+        assert by_id[21][1]["status"] == "stopped"
+
+        # Shutdown should return Goodbye
+        assert 22 in by_id
+        assert by_id[22][0] == "Goodbye"
 
     @staticmethod
     def _parse_responses(buf: bytearray) -> list:


### PR DESCRIPTION
Now I have a clear picture of the changes. Here's the PR description:

---

## Summary

Add `GateStatus` push event for gate self-observability, following the proven `SystemMetrics` pattern from ftl2-htop. Permanent gates are infrastructure that need lifecycle monitoring — this lets the AI operator answer "is the gate healthy?" alongside "is the host healthy?" via periodic push events over multiplexed SSH.

Closes #67

## Changes

- **`src/ftl2/message.py`**: Register 4 new message types (`StartGateStatus`, `StopGateStatus`, `GateStatusResult`, `GateStatus`) and add `GateStatus` to `EVENT_TYPES`
- **`src/ftl2/ftl_gate/__main__.py`**: Add `GateStatusReporter` class (~130 lines) using stdlib-only metrics (`resource.getrusage()` + `os.times()`, no psutil dependency); instrument all 4 module execution sites with task counting and error tracking; add `StartGateStatus`/`StopGateStatus` handlers in both serial and multiplexed modes
- **`src/ftl2/automation/proxy.py`**: Add `gate_status(interval=5.0)` and `ungate_status()` methods on `HostScopedProxy`, mirroring the existing `monitor()`/`unmonitor()` API
- **`tests/test_multiplexing.py`**: Update 3 existing tests for new `status_reporter` parameter; add `test_gate_status_start_stop` lifecycle test

## Test Plan

- [ ] Verify `test_gate_status_start_stop` passes — validates StartGateStatus/StopGateStatus message lifecycle
- [ ] Verify existing multiplexing tests pass with updated `status_reporter` parameter
- [ ] Manual: register `proxy.on("GateStatus", handler)` against a permanent gate and confirm events arrive at configured interval
- [ ] Verify no psutil dependency required — GateStatus uses stdlib `resource`/`os` modules only

🤖 Generated with [ftl-sdlc-loop](https://github.com/benthomasson/ftl-sdlc-loop)