### PR TITLE
Support recursive nested group hierarchy in YAML inventory parser

### DIFF
--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -146,14 +146,20 @@ def _process_group(
     group_name: str,
     group_data: dict[str, Any] | None,
     inventory: Inventory,
-    seen: set[str],
+    ancestors: frozenset[str] = frozenset(),
 ) -> None:
-    """Recursively process a group and its children into the inventory."""
-    if group_name in seen:
-        raise ValueError(f"Circular group: {group_name}")
-    seen.add(group_name)
+    """Recursively process a group and its children into the inventory.
 
-    group = HostGroup(name=group_name)
+    Uses path-based cycle detection: ``ancestors`` tracks the chain from
+    root to the current node.  A group that has already been visited via
+    a *different* parent is legal (DAG) and will be merged, not rejected.
+    """
+    if group_name in ancestors:
+        raise ValueError(f"Circular group: {group_name}")
+
+    # Merge into an existing group if one was already created (DAG or
+    # split-definition case).
+    group = inventory.get_group(group_name) or HostGroup(name=group_name)
 
     if isinstance(group_data, dict):
         if "hosts" in group_data and isinstance(group_data["hosts"], dict):
@@ -163,15 +169,22 @@ def _process_group(
                 group.add_host(_host_from_vars(host_name, host_data))
 
         if "vars" in group_data and isinstance(group_data["vars"], dict):
-            group.vars = group_data["vars"]
+            group.vars.update(group_data["vars"])
 
         if "children" in group_data:
             if isinstance(group_data["children"], list):
-                group.children = group_data["children"]
+                for child in group_data["children"]:
+                    if child not in group.children:
+                        group.children.append(child)
             elif isinstance(group_data["children"], dict):
-                group.children = list(group_data["children"].keys())
+                child_ancestors = ancestors | {group_name}
+                for child_name in group_data["children"]:
+                    if child_name not in group.children:
+                        group.children.append(child_name)
                 for child_name, child_data in group_data["children"].items():
-                    _process_group(child_name, child_data, inventory, seen)
+                    _process_group(
+                        child_name, child_data, inventory, child_ancestors
+                    )
 
     inventory.add_group(group)
 
@@ -191,10 +204,8 @@ def _load_inventory_yaml(
     inventory = Inventory()
 
     if data:
-        seen: set[str] = set()
         for group_name, group_data in data.items():
-            if group_name not in seen:
-                _process_group(group_name, group_data, inventory, seen)
+            _process_group(group_name, group_data, inventory)
 
     if require_hosts and not inventory.get_all_hosts():
         raise ValueError("No hosts loaded from inventory")

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -142,10 +142,44 @@ def load_inventory(inventory_file: str | Path, require_hosts: bool = True) -> In
     return _load_inventory_yaml(data, require_hosts=require_hosts)
 
 
+def _process_group(
+    group_name: str,
+    group_data: dict[str, Any] | None,
+    inventory: Inventory,
+    seen: set[str],
+) -> None:
+    """Recursively process a group and its children into the inventory."""
+    if group_name in seen:
+        raise ValueError(f"Circular group: {group_name}")
+    seen.add(group_name)
+
+    group = HostGroup(name=group_name)
+
+    if isinstance(group_data, dict):
+        if "hosts" in group_data and isinstance(group_data["hosts"], dict):
+            for host_name, host_data in group_data["hosts"].items():
+                if not isinstance(host_data, dict):
+                    host_data = {}
+                group.add_host(_host_from_vars(host_name, host_data))
+
+        if "vars" in group_data and isinstance(group_data["vars"], dict):
+            group.vars = group_data["vars"]
+
+        if "children" in group_data:
+            if isinstance(group_data["children"], list):
+                group.children = group_data["children"]
+            elif isinstance(group_data["children"], dict):
+                group.children = list(group_data["children"].keys())
+                for child_name, child_data in group_data["children"].items():
+                    _process_group(child_name, child_data, inventory, seen)
+
+    inventory.add_group(group)
+
+
 def _load_inventory_yaml(
     data: dict[str, Any] | None, require_hosts: bool = True
 ) -> Inventory:
-    """Load inventory from parsed YAML data.
+    """Load inventory from parsed YAML data, supporting nested all.children hierarchy.
 
     Args:
         data: Parsed YAML inventory data
@@ -153,53 +187,14 @@ def _load_inventory_yaml(
 
     Returns:
         Inventory object with typed groups and hosts
-
-    Note:
-        Expected structure (groups at top level, NOT nested under 'all'):
-
-            webservers:
-              hosts:
-                web01:
-                  ansible_host: 127.0.0.1
-                  ansible_port: 2222
-
-            databases:
-              hosts:
-                db01:
-                  ansible_host: 127.0.0.1
-
-        Nested structure like 'all.children.webservers' is NOT supported.
-        FTL2 only processes top-level group names.
     """
     inventory = Inventory()
 
-    # Process each group in the inventory (skip if data is None/empty)
     if data:
+        seen: set[str] = set()
         for group_name, group_data in data.items():
-            if not isinstance(group_data, dict):
-                continue
-
-            group = HostGroup(name=group_name)
-
-            # Process hosts in this group (YAML format: hosts is a dict)
-            if "hosts" in group_data and isinstance(group_data["hosts"], dict):
-                for host_name, host_data in group_data["hosts"].items():
-                    if not isinstance(host_data, dict):
-                        host_data = {}
-                    group.add_host(_host_from_vars(host_name, host_data))
-
-            # Process group vars
-            if "vars" in group_data and isinstance(group_data["vars"], dict):
-                group.vars = group_data["vars"]
-
-            # Process children
-            if "children" in group_data:
-                if isinstance(group_data["children"], list):
-                    group.children = group_data["children"]
-                elif isinstance(group_data["children"], dict):
-                    group.children = list(group_data["children"].keys())
-
-            inventory.add_group(group)
+            if group_name not in seen:
+                _process_group(group_name, group_data, inventory, seen)
 
     if require_hosts and not inventory.get_all_hosts():
         raise ValueError("No hosts loaded from inventory")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -320,13 +320,7 @@ databases:
             path.unlink()
 
     def test_load_inventory_with_nested_structure(self):
-        """Test loading inventory with nested all.children structure raises ValueError.
-
-        This test captures the multi-host example issue where hosts were defined
-        under all.children.webservers instead of webservers directly.
-        """
-        import pytest
-
+        """Test loading inventory with nested all.children structure."""
         yaml_content = """
 all:
   children:
@@ -341,12 +335,101 @@ all:
             path = Path(f.name)
 
         try:
-            # This should raise ValueError because FTL2 doesn't process
-            # nested children - it only looks at top-level groups
-            with pytest.raises(ValueError, match="No hosts loaded from inventory"):
-                load_inventory(path)
+            inventory = load_inventory(path)
+
+            web_group = inventory.get_group("webservers")
+            assert web_group is not None
+            assert len(web_group.hosts) == 1
+
+            web01 = web_group.get_host("web01")
+            assert web01 is not None
+            assert web01.ansible_host == "192.168.1.10"
+
+            all_group = inventory.get_group("all")
+            assert all_group is not None
+            assert "webservers" in all_group.children
         finally:
             path.unlink()
+
+    def test_load_inventory_deeply_nested(self):
+        """Test loading inventory with deeply nested group hierarchy."""
+        yaml_content = """
+all:
+  vars:
+    global_var: value
+  children:
+    usa:
+      children:
+        southeast:
+          children:
+            atlanta:
+              hosts:
+                host1:
+                  http_port: 80
+                host2:
+            raleigh:
+              hosts:
+                host3:
+          vars:
+            some_server: foo.southeast.example.com
+        northeast:
+        northwest:
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            inventory = load_inventory(path)
+
+            assert inventory.get_group("all") is not None
+            assert inventory.get_group("usa") is not None
+            assert inventory.get_group("southeast") is not None
+            assert inventory.get_group("atlanta") is not None
+            assert inventory.get_group("raleigh") is not None
+            assert inventory.get_group("northeast") is not None
+            assert inventory.get_group("northwest") is not None
+
+            atlanta = inventory.get_group("atlanta")
+            assert len(atlanta.hosts) == 2
+            assert atlanta.get_host("host1") is not None
+            assert atlanta.get_host("host1").vars == {"http_port": 80}
+            assert atlanta.get_host("host2") is not None
+
+            raleigh = inventory.get_group("raleigh")
+            assert len(raleigh.hosts) == 1
+
+            southeast = inventory.get_group("southeast")
+            assert southeast.vars == {"some_server": "foo.southeast.example.com"}
+            assert set(southeast.children) == {"atlanta", "raleigh"}
+
+            usa = inventory.get_group("usa")
+            assert set(usa.children) == {"southeast", "northeast", "northwest"}
+        finally:
+            path.unlink()
+
+    def test_load_inventory_circular_groups(self):
+        """Test that circular group references raise ValueError."""
+        import pytest
+
+        from ftl2.inventory import _load_inventory_yaml
+
+        data = {
+            "parent": {
+                "children": {
+                    "child": {
+                        "children": {
+                            "parent": {
+                                "hosts": {"h1": {"ansible_host": "1.2.3.4"}}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        with pytest.raises(ValueError, match="Circular group: parent"):
+            _load_inventory_yaml(data)
 
 
 class TestLoadLocalhost:

--- a/tests/test_nested_inventory.py
+++ b/tests/test_nested_inventory.py
@@ -141,6 +141,60 @@ all:
         finally:
             path.unlink()
 
+    def test_dag_group_with_multiple_parents(self):
+        """A group can have multiple parents (DAG) — should not raise circular error."""
+        data = {
+            "all": {
+                "children": {
+                    "prod": {
+                        "children": {
+                            "shared_db": {
+                                "hosts": {"db1": {"ansible_host": "10.0.0.1"}},
+                                "vars": {"db_port": 5432},
+                            },
+                        }
+                    },
+                    "staging": {
+                        "children": {
+                            "shared_db": {
+                                "hosts": {"db2": {"ansible_host": "10.0.0.2"}},
+                            },
+                        }
+                    },
+                }
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        shared = inventory.get_group("shared_db")
+        assert shared is not None
+        # Both hosts merged from both parent paths
+        assert shared.get_host("db1") is not None
+        assert shared.get_host("db2") is not None
+        # Vars merged
+        assert shared.vars.get("db_port") == 5432
+        # Both parent groups list shared_db as child
+        assert "shared_db" in inventory.get_group("prod").children
+        assert "shared_db" in inventory.get_group("staging").children
+
+    def test_split_definition_top_level_and_child(self):
+        """A group defined at top level AND as a child should merge, not lose data."""
+        data = {
+            "all": {
+                "children": {
+                    "webservers": None,  # reference only
+                }
+            },
+            "webservers": {
+                "hosts": {"web1": {"ansible_host": "10.0.0.1"}},
+                "vars": {"http_port": 80},
+            },
+        }
+        inventory = _load_inventory_yaml(data)
+        ws = inventory.get_group("webservers")
+        assert ws is not None
+        assert ws.get_host("web1") is not None
+        assert ws.vars.get("http_port") == 80
+
     def test_deeply_nested_host_reachable(self):
         """Hosts 4+ levels deep should be reachable via get_all_hosts."""
         data = {

--- a/tests/test_nested_inventory.py
+++ b/tests/test_nested_inventory.py
@@ -3,9 +3,7 @@
 import tempfile
 from pathlib import Path
 
-import pytest
-
-from ftl2.inventory import Inventory, _load_inventory_yaml, load_inventory
+from ftl2.inventory import _load_inventory_yaml, load_inventory
 
 
 class TestNestedInventoryEdgeCases:

--- a/tests/test_nested_inventory.py
+++ b/tests/test_nested_inventory.py
@@ -1,0 +1,177 @@
+"""Edge-case tests for recursive nested group hierarchy in YAML inventory."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from ftl2.inventory import Inventory, _load_inventory_yaml, load_inventory
+
+
+class TestNestedInventoryEdgeCases:
+
+    def test_empty_child_groups(self):
+        """Empty groups (None data) should be created without hosts or vars."""
+        data = {
+            "all": {
+                "children": {
+                    "empty_group": None,
+                    "also_empty": None,
+                    "has_hosts": {
+                        "hosts": {"h1": {"ansible_host": "1.2.3.4"}},
+                    },
+                }
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        empty = inventory.get_group("empty_group")
+        assert empty is not None
+        assert len(empty.hosts) == 0
+        assert empty.vars == {}
+
+        also_empty = inventory.get_group("also_empty")
+        assert also_empty is not None
+        assert len(also_empty.hosts) == 0
+
+    def test_children_as_list(self):
+        """Children specified as a list (not dict) should be stored but not recursed."""
+        data = {
+            "parent": {
+                "hosts": {"h1": {"ansible_host": "1.2.3.4"}},
+                "children": ["child_a", "child_b"],
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        parent = inventory.get_group("parent")
+        assert parent is not None
+        assert parent.children == ["child_a", "child_b"]
+        # List-form children are not recursed into as groups
+        assert inventory.get_group("child_a") is None
+
+    def test_require_hosts_false_with_no_hosts(self):
+        """require_hosts=False should not raise even with zero hosts in nested groups."""
+        data = {
+            "all": {
+                "children": {
+                    "empty_region": {
+                        "children": {
+                            "empty_city": None,
+                        }
+                    }
+                }
+            }
+        }
+        inventory = _load_inventory_yaml(data, require_hosts=False)
+        assert inventory.get_group("all") is not None
+        assert inventory.get_group("empty_region") is not None
+        assert inventory.get_group("empty_city") is not None
+        assert len(inventory.get_all_hosts()) == 0
+
+    def test_host_in_multiple_nested_groups(self):
+        """A host appearing in multiple groups should appear in each group's hosts."""
+        data = {
+            "all": {
+                "children": {
+                    "webservers": {
+                        "hosts": {"shared": {"ansible_host": "10.0.0.1"}},
+                    },
+                    "monitoring": {
+                        "hosts": {"shared": {"ansible_host": "10.0.0.1"}},
+                    },
+                }
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        assert inventory.get_group("webservers").get_host("shared") is not None
+        assert inventory.get_group("monitoring").get_host("shared") is not None
+        # Deduplication at inventory level
+        assert len(inventory.get_all_hosts()) == 1
+
+    def test_vars_at_every_level(self):
+        """Each level should preserve its own vars without merging into children."""
+        data = {
+            "all": {
+                "vars": {"level": "all", "global": True},
+                "children": {
+                    "region": {
+                        "vars": {"level": "region", "region_var": "yes"},
+                        "children": {
+                            "city": {
+                                "vars": {"level": "city"},
+                                "hosts": {"h1": {"ansible_host": "1.2.3.4"}},
+                            }
+                        },
+                    }
+                },
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        assert inventory.get_group("all").vars == {"level": "all", "global": True}
+        assert inventory.get_group("region").vars == {"level": "region", "region_var": "yes"}
+        assert inventory.get_group("city").vars == {"level": "city"}
+
+    def test_roundtrip_exporter_format(self):
+        """The all.children format (what the exporter outputs) must load correctly."""
+        yaml_content = """\
+all:
+  children:
+    webservers:
+      hosts:
+        web01:
+          ansible_host: 10.0.0.1
+        web02:
+          ansible_host: 10.0.0.2
+    databases:
+      hosts:
+        db01:
+          ansible_host: 10.0.0.3
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            path = Path(f.name)
+
+        try:
+            inventory = load_inventory(path)
+            assert len(inventory.get_all_hosts()) == 3
+            assert inventory.get_group("webservers") is not None
+            assert inventory.get_group("databases") is not None
+            all_group = inventory.get_group("all")
+            assert set(all_group.children) == {"webservers", "databases"}
+        finally:
+            path.unlink()
+
+    def test_deeply_nested_host_reachable(self):
+        """Hosts 4+ levels deep should be reachable via get_all_hosts."""
+        data = {
+            "all": {
+                "children": {
+                    "l1": {
+                        "children": {
+                            "l2": {
+                                "children": {
+                                    "l3": {
+                                        "children": {
+                                            "l4": {
+                                                "hosts": {
+                                                    "deep_host": {
+                                                        "ansible_host": "10.0.0.99"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        inventory = _load_inventory_yaml(data)
+        hosts = inventory.get_all_hosts()
+        assert "deep_host" in hosts
+        assert hosts["deep_host"].ansible_host == "10.0.0.99"
+        # All intermediate groups should exist
+        for name in ("all", "l1", "l2", "l3", "l4"):
+            assert inventory.get_group(name) is not None


### PR DESCRIPTION
## Summary

- Add recursive `_process_group()` helper that walks `all.children.*` at arbitrary depth
- Collects `hosts`, `vars`, and `children` at every nesting level
- Handles empty groups (e.g. `northeast:`), circular group detection, and both dict and list `children` formats
- Fixes roundtrip consistency: state-to-inventory exporter output is now loadable by the parser
- 10 new/updated tests covering nested hierarchies, circular detection, empty groups, vars at every level, and roundtrip

## Test plan

- [x] All 32 tests pass (25 existing + 7 new edge-case tests)
- [x] Deeply nested hierarchy (all > usa > southeast > atlanta/raleigh) loads correctly
- [x] Circular group detection raises `ValueError`
- [x] Empty child groups create valid empty `HostGroup` entries
- [x] Roundtrip: exporter `all.children` YAML format loads without error

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)