### PR TITLE
Support host range patterns in inventory files

### DIFF
--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -247,8 +247,6 @@ def _host_from_vars(host_name: str, host_data: dict[str, Any]) -> HostConfig:
     )
 
 
-_NUMERIC_RANGE_RE = re.compile(r"\[([0-9]+):([0-9]+)(?::([0-9]+))?\]")
-_ALPHA_RANGE_RE = re.compile(r"\[([a-zA-Z]):([a-zA-Z])(?::([0-9]+))?\]")
 _RANGE_RE = re.compile(
     r"\[([0-9]+):([0-9]+)(?::([0-9]+))?\]"
     r"|"

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -247,11 +247,23 @@ def _host_from_vars(host_name: str, host_data: dict[str, Any]) -> HostConfig:
     )
 
 
-_RANGE_RE = re.compile(r"\[([a-zA-Z0-9]+:[a-zA-Z0-9]+(?::[0-9]+)?)\]")
+_NUMERIC_RANGE_RE = re.compile(r"\[([0-9]+):([0-9]+)(?::([0-9]+))?\]")
+_ALPHA_RANGE_RE = re.compile(r"\[([a-zA-Z]):([a-zA-Z])(?::([0-9]+))?\]")
+_RANGE_RE = re.compile(
+    r"\[([0-9]+):([0-9]+)(?::([0-9]+))?\]"
+    r"|"
+    r"\[([a-zA-Z]):([a-zA-Z])(?::([0-9]+))?\]"
+)
 
 
 def expand_host_range(pattern: str) -> list[str]:
-    """Expand Ansible host range patterns like ``www[01:50].example.com``."""
+    """Expand Ansible host range patterns like ``www[01:50].example.com``.
+
+    Supports numeric ranges (``[01:50]``), alphabetic ranges (``[a:f]``),
+    and stride (``[01:50:2]``).  Multiple bracket groups produce a cartesian
+    product.  Brackets that don't match valid range syntax are left as
+    literal characters.
+    """
     matches = list(_RANGE_RE.finditer(pattern))
     if not matches:
         return [pattern]
@@ -260,15 +272,23 @@ def expand_host_range(pattern: str) -> list[str]:
     last_end = 0
     for m in matches:
         segments.append([pattern[last_end : m.start()]])
-        parts = m.group(1).split(":")
-        start, end = parts[0], parts[1]
-        stride = int(parts[2]) if len(parts) > 2 else 1
 
-        if start.isdigit() and end.isdigit():
-            width = len(start)
+        if m.group(1) is not None:
+            # Numeric range
+            start, end = m.group(1), m.group(2)
+            stride = int(m.group(3)) if m.group(3) else 1
+            if stride == 0:
+                raise ValueError(f"Invalid host range stride of 0 in '{pattern}'")
+            width = max(len(start), len(end))
             vals = [str(i).zfill(width) for i in range(int(start), int(end) + 1, stride)]
         else:
+            # Alpha range
+            start, end = m.group(4), m.group(5)
+            stride = int(m.group(6)) if m.group(6) else 1
+            if stride == 0:
+                raise ValueError(f"Invalid host range stride of 0 in '{pattern}'")
             vals = [chr(c) for c in range(ord(start), ord(end) + 1, stride)]
+
         segments.append(vals)
         last_end = m.end()
 

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -247,7 +247,7 @@ def _host_from_vars(host_name: str, host_data: dict[str, Any]) -> HostConfig:
     )
 
 
-_RANGE_RE = re.compile(r"\[([^\]]+)\]")
+_RANGE_RE = re.compile(r"\[([a-zA-Z0-9]+:[a-zA-Z0-9]+(?::[0-9]+)?)\]")
 
 
 def expand_host_range(pattern: str) -> list[str]:

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -4,8 +4,10 @@ This module provides typed inventory management with dataclasses, replacing
 dictionary-based inventory structures with strongly-typed classes.
 """
 
+import itertools
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -166,7 +168,8 @@ def _process_group(
             for host_name, host_data in group_data["hosts"].items():
                 if not isinstance(host_data, dict):
                     host_data = {}
-                group.add_host(_host_from_vars(host_name, host_data))
+                for expanded in expand_host_range(host_name):
+                    group.add_host(_host_from_vars(expanded, host_data))
 
         if "vars" in group_data and isinstance(group_data["vars"], dict):
             group.vars.update(group_data["vars"])
@@ -242,6 +245,35 @@ def _host_from_vars(host_name: str, host_data: dict[str, Any]) -> HostConfig:
         ),
         vars={k: v for k, v in host_data.items() if k not in standard_fields},
     )
+
+
+_RANGE_RE = re.compile(r"\[([^\]]+)\]")
+
+
+def expand_host_range(pattern: str) -> list[str]:
+    """Expand Ansible host range patterns like ``www[01:50].example.com``."""
+    matches = list(_RANGE_RE.finditer(pattern))
+    if not matches:
+        return [pattern]
+
+    segments: list[list[str]] = []
+    last_end = 0
+    for m in matches:
+        segments.append([pattern[last_end : m.start()]])
+        parts = m.group(1).split(":")
+        start, end = parts[0], parts[1]
+        stride = int(parts[2]) if len(parts) > 2 else 1
+
+        if start.isdigit() and end.isdigit():
+            width = len(start)
+            vals = [str(i).zfill(width) for i in range(int(start), int(end) + 1, stride)]
+        else:
+            vals = [chr(c) for c in range(ord(start), ord(end) + 1, stride)]
+        segments.append(vals)
+        last_end = m.end()
+
+    segments.append([pattern[last_end:]])
+    return ["".join(combo) for combo in itertools.product(*segments)]
 
 
 def load_inventory_json(data: dict[str, Any], require_hosts: bool = True) -> Inventory:

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -5,6 +5,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from ftl2.inventory import (
     HostGroup,
     Inventory,
@@ -782,9 +784,27 @@ class TestExpandHostRange:
         """Brackets without colon are not range syntax — pass through literally."""
         assert expand_host_range("host[tag]") == ["host[tag]"]
 
+    def test_multi_char_alpha_passthrough(self):
+        """Multi-character alpha brackets are not valid ranges — pass through."""
+        assert expand_host_range("host[tag:value]") == ["host[tag:value]"]
+
+    def test_ipv6_like_passthrough(self):
+        """IPv6-like brackets are not valid ranges — pass through."""
+        assert expand_host_range("host[2001:db8]") == ["host[2001:db8]"]
+
     def test_descending_range_empty(self):
         """Descending range produces no values — returns empty list."""
         assert expand_host_range("host[5:1]") == []
+
+    def test_zero_stride_raises(self):
+        """Stride of 0 raises ValueError."""
+        with pytest.raises(ValueError, match="stride of 0"):
+            expand_host_range("host[1:5:0]")
+
+    def test_width_from_longer_side(self):
+        """Zero-padding uses the wider of start/end."""
+        result = expand_host_range("host[1:003]")
+        assert result == ["host001", "host002", "host003"]
 
 
 class TestHostRangeIntegration:

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from ftl2.inventory import (
     HostGroup,
     Inventory,
+    expand_host_range,
     load_inventory,
     load_inventory_json,
     load_inventory_script,
@@ -715,3 +716,117 @@ class TestLoadInventoryScript:
             assert ws.vars == {"http_port": 80}
         finally:
             path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Host range expansion
+# ---------------------------------------------------------------------------
+
+
+class TestExpandHostRange:
+    """Tests for expand_host_range()."""
+
+    def test_numeric_range(self):
+        result = expand_host_range("www[01:03].example.com")
+        assert result == [
+            "www01.example.com",
+            "www02.example.com",
+            "www03.example.com",
+        ]
+
+    def test_numeric_range_leading_zeros(self):
+        result = expand_host_range("node[001:003]")
+        assert result == ["node001", "node002", "node003"]
+
+    def test_alphabetic_range(self):
+        result = expand_host_range("db-[a:f].example.com")
+        assert result == [
+            "db-a.example.com",
+            "db-b.example.com",
+            "db-c.example.com",
+            "db-d.example.com",
+            "db-e.example.com",
+            "db-f.example.com",
+        ]
+
+    def test_numeric_stride(self):
+        result = expand_host_range("www[01:10:3].example.com")
+        assert result == [
+            "www01.example.com",
+            "www04.example.com",
+            "www07.example.com",
+            "www10.example.com",
+        ]
+
+    def test_alpha_stride(self):
+        result = expand_host_range("db-[a:f:2].local")
+        assert result == ["db-a.local", "db-c.local", "db-e.local"]
+
+    def test_no_range_passthrough(self):
+        assert expand_host_range("plain-host") == ["plain-host"]
+
+    def test_multiple_ranges_cartesian(self):
+        result = expand_host_range("rack[1:2]-node[a:b]")
+        assert result == [
+            "rack1-nodea",
+            "rack1-nodeb",
+            "rack2-nodea",
+            "rack2-nodeb",
+        ]
+
+    def test_single_value_range(self):
+        result = expand_host_range("host[5:5]")
+        assert result == ["host5"]
+
+
+class TestHostRangeIntegration:
+    """Test host range expansion through YAML inventory loading."""
+
+    def test_yaml_inventory_with_ranges(self, tmp_path):
+        inv_file = tmp_path / "inventory.yaml"
+        inv_file.write_text(
+            "webservers:\n"
+            "  hosts:\n"
+            "    www[01:03].example.com:\n"
+            "      ansible_user: deploy\n"
+        )
+        inventory = load_inventory(str(inv_file))
+        ws = inventory.get_group("webservers")
+        assert ws is not None
+        hosts = sorted(ws.hosts.keys())
+        assert hosts == [
+            "www01.example.com",
+            "www02.example.com",
+            "www03.example.com",
+        ]
+        for h in ws.hosts.values():
+            assert h.ansible_user == "deploy"
+
+    def test_yaml_inventory_alpha_range(self, tmp_path):
+        inv_file = tmp_path / "inventory.yaml"
+        inv_file.write_text(
+            "databases:\n"
+            "  hosts:\n"
+            "    db-[a:c].internal:\n"
+        )
+        inventory = load_inventory(str(inv_file))
+        db = inventory.get_group("databases")
+        assert sorted(db.hosts.keys()) == [
+            "db-a.internal",
+            "db-b.internal",
+            "db-c.internal",
+        ]
+
+    def test_mixed_range_and_plain_hosts(self, tmp_path):
+        inv_file = tmp_path / "inventory.yaml"
+        inv_file.write_text(
+            "cluster:\n"
+            "  hosts:\n"
+            "    node[1:3]:\n"
+            "    bastion:\n"
+        )
+        inventory = load_inventory(str(inv_file))
+        grp = inventory.get_group("cluster")
+        assert sorted(grp.hosts.keys()) == [
+            "bastion", "node1", "node2", "node3",
+        ]

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -778,6 +778,14 @@ class TestExpandHostRange:
         result = expand_host_range("host[5:5]")
         assert result == ["host5"]
 
+    def test_non_range_brackets_passthrough(self):
+        """Brackets without colon are not range syntax — pass through literally."""
+        assert expand_host_range("host[tag]") == ["host[tag]"]
+
+    def test_descending_range_empty(self):
+        """Descending range produces no values — returns empty list."""
+        assert expand_host_range("host[5:1]") == []
+
 
 class TestHostRangeIntegration:
     """Test host range expansion through YAML inventory loading."""


### PR DESCRIPTION
## Summary

- Adds `expand_host_range()` for Ansible-style patterns: `www[01:50].example.com`
- Numeric ranges with leading zero preservation, alphabetic ranges, stride
- Cartesian product for multiple bracket groups: `rack[1:2]-node[a:b]`
- Expansion at YAML parse time; host vars propagate to all expanded hosts
- 11 new tests (unit + integration through YAML loading)

## Test plan

- [x] All 47 inventory tests pass
- [x] Full suite: 1816 passed, 0 failed, 8 skipped
- [x] CI validates on Ubuntu runner

Closes #106