### PR TITLE
Fix state-to-inventory roundtrip: exporter output must be loadable

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -225,6 +225,8 @@ class TestStateToInventoryRoundTrip:
 
         yaml_out = state_to_inventory(state)
 
+        assert yaml_out.startswith("all:\n  children:\n")
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
             f.write(yaml_out)
             f.flush()
@@ -314,6 +316,167 @@ class TestStateToInventoryRoundTrip:
             inventory = load_inventory(f.name, require_hosts=False)
 
         assert len(inventory.get_all_hosts()) == 0
+
+    def test_host_in_multiple_groups_round_trip(self):
+        """Host appearing in multiple groups is present in all after roundtrip."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "app01": {
+                    "ansible_host": "10.0.0.1",
+                    "ansible_user": "deploy",
+                    "groups": ["webservers", "monitoring", "production"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+        assert "all:" in yaml_out
+        assert "children:" in yaml_out
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert "app01" in hosts
+        assert hosts["app01"].ansible_host == "10.0.0.1"
+        assert hosts["app01"].ansible_user == "deploy"
+
+        for group_name in ("webservers", "monitoring", "production"):
+            group = inventory.get_group(group_name)
+            assert group is not None, f"Group {group_name} missing"
+            assert "app01" in group.hosts
+
+    def test_host_with_custom_port_round_trip(self):
+        """Non-default ansible_port survives roundtrip."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "bastion": {
+                    "ansible_host": "203.0.113.1",
+                    "ansible_port": 2222,
+                    "groups": ["jump"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+        assert "2222" in yaml_out
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert hosts["bastion"].ansible_port == 2222
+
+    def test_host_with_python_interpreter_round_trip(self):
+        """Custom ansible_python_interpreter survives roundtrip."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                "legacy": {
+                    "ansible_host": "10.0.0.99",
+                    "ansible_python_interpreter": "/usr/bin/python3.9",
+                    "groups": ["old"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert hosts["legacy"].ansible_python_interpreter == "/usr/bin/python3.9"
+
+    def test_many_hosts_many_groups_round_trip(self):
+        """Larger inventory with many hosts and groups roundtrips correctly."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        from ftl2.inventory import load_inventory
+
+        state = {
+            "hosts": {
+                f"node{i:02d}": {
+                    "ansible_host": f"10.0.0.{i}",
+                    "groups": [f"tier{i % 3}"],
+                }
+                for i in range(1, 11)
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(yaml_out)
+            f.flush()
+            inventory = load_inventory(f.name)
+
+        hosts = inventory.get_all_hosts()
+        assert len(hosts) == 10
+        for i in range(1, 11):
+            name = f"node{i:02d}"
+            assert name in hosts
+            assert hosts[name].ansible_host == f"10.0.0.{i}"
+
+    def test_yaml_output_is_parseable_yaml(self):
+        """Exported YAML is valid YAML that parses to the expected structure."""
+        import yaml as pyyaml
+
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        state = {
+            "hosts": {
+                "web01": {
+                    "ansible_host": "1.2.3.4",
+                    "groups": ["webservers"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+        parsed = pyyaml.safe_load(yaml_out)
+
+        assert "all" in parsed
+        assert "children" in parsed["all"]
+        assert "webservers" in parsed["all"]["children"]
+        assert "hosts" in parsed["all"]["children"]["webservers"]
+        assert "web01" in parsed["all"]["children"]["webservers"]["hosts"]
+
+    def test_default_port_and_connection_omitted(self):
+        """Default ansible_port=22 and ansible_connection=ssh are not in output."""
+        from tools.ftl2_state_to_inventory import state_to_inventory
+
+        state = {
+            "hosts": {
+                "srv01": {
+                    "ansible_host": "10.0.0.1",
+                    "ansible_port": 22,
+                    "ansible_connection": "ssh",
+                    "groups": ["servers"],
+                },
+            },
+        }
+
+        yaml_out = state_to_inventory(state)
+        assert "ansible_port" not in yaml_out
+        assert "ansible_connection" not in yaml_out
 
 
 class TestMergeStateIntoInventory:

--- a/tools/ftl2_state_to_inventory.py
+++ b/tools/ftl2_state_to_inventory.py
@@ -15,16 +15,11 @@ import sys
 
 
 def state_to_inventory(state: dict) -> str:
-    """Convert state dict to YAML inventory string.
-
-    Outputs groups at the top level (not nested under all.children)
-    so the result can be loaded by ftl2's inventory loader.
-    """
+    """Convert state dict to YAML inventory string."""
     hosts = state.get("hosts", {})
     if not hosts:
         return "all:\n  hosts: {}\n"
 
-    # Group hosts by their groups
     groups: dict[str, dict[str, dict]] = {}
     for host_name, host_data in hosts.items():
         host_groups = host_data.get("groups", ["ungrouped"])
@@ -33,7 +28,6 @@ def state_to_inventory(state: dict) -> str:
                      "ansible_connection", "ansible_python_interpreter"):
             if key in host_data:
                 val = host_data[key]
-                # Skip defaults
                 if key == "ansible_port" and val == 22:
                     continue
                 if key == "ansible_connection" and val == "ssh":
@@ -44,14 +38,13 @@ def state_to_inventory(state: dict) -> str:
         for group in host_groups:
             groups.setdefault(group, {})[host_name] = host_vars
 
-    # Build YAML with groups at the top level (compatible with ftl2 loader)
-    lines = []
+    lines = ["all:", "  children:"]
     for group_name in sorted(groups):
         group_hosts = groups[group_name]
-        lines.append(f"{group_name}:")
-        lines.append(f"  hosts:")
+        lines.append(f"    {group_name}:")
+        lines.append(f"      hosts:")
         for host_name in sorted(group_hosts):
-            _append_host(lines, host_name, group_hosts[host_name], indent=4)
+            _append_host(lines, host_name, group_hosts[host_name], indent=8)
 
     return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
Here's the PR description:

## Summary

Fix the state-to-inventory exporter to output `all.children` YAML structure that FTL2's inventory loader can parse. Previously the exporter emitted groups at the top level, which `load_inventory()` could not read back, breaking the roundtrip. The exporter now wraps groups under `all: children:` with correct indentation.

Closes #109

## Changes

- Updated `state_to_inventory()` in `tools/ftl2_state_to_inventory.py` to emit groups nested under `all.children` instead of at the top level
- Adjusted indentation from 0/2/4 spaces to 4/6/8 spaces to match the `all.children` nesting
- Added assertion in roundtrip test to verify output starts with `all:\n  children:\n`
- Removed stale comments that described the old (incompatible) output format

## Test Plan

- [x] `test_single_group_round_trip` — exports single-group state, loads with `load_inventory()`, verifies hosts and variables
- [x] `test_multiple_groups_round_trip` — exports multi-group state, verifies all groups and host variables survive
- [x] `test_ungrouped_round_trip` — verifies hosts without explicit groups land in `ungrouped`
- [ ] Run `pytest tests/test_state.py` to confirm all roundtrip tests pass

🤖 Generated with [ftl-sdlc-loop](https://github.com/benthomasson/ftl-sdlc-loop)