### PR TITLE
Add opt-in production coverage collection (GH-102)

### DIFF
--- a/src/ftl2/cli.py
+++ b/src/ftl2/cli.py
@@ -2161,7 +2161,15 @@ def main() -> None:
     from ftl2.telemetry import phone_home
 
     phone_home()
-    cli()
+
+    # To collect coverage, set FTL2_COVERAGE=1 in your environment.
+    from ftl2.coverage import ControllerCoverage, is_coverage_enabled
+
+    if is_coverage_enabled():
+        with ControllerCoverage():
+            cli()
+    else:
+        cli()
 
 
 def entry_point() -> None:

--- a/src/ftl2/coverage.py
+++ b/src/ftl2/coverage.py
@@ -1,0 +1,89 @@
+"""FTL2 production coverage collection — opt-in via FTL2_COVERAGE=1.
+
+Collects coverage from the controller process and (when available) from
+remote gate processes.  No hard dependency on coverage.py — everything
+degrades to a silent no-op when the package is absent.
+
+To enable:  FTL2_COVERAGE=1 ftl2 run ...
+Custom dir: FTL2_COVERAGE_DIR=~/my-cov ftl2 run ...
+"""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def is_coverage_enabled() -> bool:
+    """Return True when coverage collection is opted-in."""
+    return os.environ.get("FTL2_COVERAGE", "") == "1"
+
+
+def coverage_dir() -> Path:
+    """Return (and create) the directory for coverage data files."""
+    d = Path(os.environ.get("FTL2_COVERAGE_DIR", "~/.ftl/coverage")).expanduser()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+class ControllerCoverage:
+    """Context manager that wraps the controller process with coverage.py.
+
+    Usage::
+
+        with ControllerCoverage():
+            cli()
+    """
+
+    def __init__(self) -> None:
+        self._cov = None
+
+    def __enter__(self) -> "ControllerCoverage":
+        try:
+            import coverage
+
+            data_file = str(coverage_dir() / f".coverage.controller.{os.getpid()}")
+            self._cov = coverage.Coverage(data_file=data_file)
+            self._cov.start()
+            logger.debug("Controller coverage started: %s", data_file)
+        except ImportError:
+            logger.debug("coverage package not installed — skipping controller coverage")
+        except Exception:
+            logger.debug("Failed to start controller coverage", exc_info=True)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        if self._cov is not None:
+            try:
+                self._cov.stop()
+                self._cov.save()
+                logger.debug("Controller coverage saved")
+            except Exception:
+                logger.debug("Failed to save controller coverage", exc_info=True)
+
+
+async def retrieve_gate_coverage(
+    conn,
+    remote_path: str,
+    host_name: str,
+) -> bool:
+    """SFTP a gate coverage file back to the controller.
+
+    Args:
+        conn: Active asyncssh SSHClientConnection
+        remote_path: Absolute path to .coverage file on the remote host
+        host_name: Logical host name (used in the local filename)
+
+    Returns:
+        True if retrieval succeeded, False otherwise
+    """
+    try:
+        local = coverage_dir() / f".coverage.gate.{host_name}.{os.getpid()}"
+        async with conn.start_sftp_client() as sftp:
+            await sftp.get(remote_path, str(local))
+        logger.debug("Gate coverage retrieved: %s -> %s", remote_path, local)
+        return True
+    except Exception:
+        logger.debug("Failed to retrieve gate coverage from %s", host_name, exc_info=True)
+        return False

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -338,6 +338,25 @@ _gate_cov: Any = None
 _gate_coverage_file: str | None = None
 
 
+def _stop_gate_coverage() -> str:
+    """Stop coverage collection and return the data file path.
+
+    Returns empty string if coverage was not active.
+    Resets global state so subsequent calls are no-ops.
+    """
+    global _gate_cov
+    path = ""
+    if _gate_cov is not None:
+        try:
+            _gate_cov.stop()
+            _gate_cov.save()
+            path = _gate_coverage_file or ""
+        except Exception:
+            logger.debug("Failed to save gate coverage", exc_info=True)
+        _gate_cov = None
+    return path
+
+
 def _module_cache_set(name: str, data: bytes) -> None:
     """Store a module in the bounded cache, evicting the oldest entry if full."""
     if name in _module_cache:
@@ -1120,7 +1139,8 @@ async def main(args: list[str]) -> int | None:
     _gate_cov = None
     _gate_coverage_file = None
     if HAS_COVERAGE and os.environ.get("FTL2_COVERAGE") == "1":
-        _gate_coverage_file = f"/tmp/.coverage.gate.{os.getpid()}"
+        cov_dir = tempfile.mkdtemp(prefix="ftl2-cov-")
+        _gate_coverage_file = f"{cov_dir}/.coverage.gate.{os.getpid()}"
         _gate_cov = _coverage_mod.Coverage(data_file=_gate_coverage_file)
         _gate_cov.start()
         logger.info(f"Coverage started: {_gate_coverage_file}")
@@ -1420,12 +1440,7 @@ async def main(args: list[str]) -> int | None:
 
             elif msg_type == "GetCoverage":
                 logger.info("GetCoverage requested")
-                cov_path = ""
-                if _gate_cov is not None:
-                    _gate_cov.stop()
-                    _gate_cov.save()
-                    cov_path = _gate_coverage_file or ""
-                    _gate_cov = None
+                cov_path = _stop_gate_coverage()
                 await protocol.send_message(
                     writer, "GetCoverageResult", {"path": cov_path}
                 )
@@ -1435,10 +1450,7 @@ async def main(args: list[str]) -> int | None:
                 watcher.stop()
                 monitor.stop()
                 gate_status_monitor.stop()
-                if _gate_cov is not None:
-                    _gate_cov.stop()
-                    _gate_cov.save()
-                    _gate_cov = None
+                _stop_gate_coverage()
                 await protocol.send_message(writer, "Goodbye", {})
                 return None
 
@@ -1761,12 +1773,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
             # Handle GetCoverage synchronously
             if msg_type == "GetCoverage":
                 logger.info("GetCoverage requested in multiplexed mode")
-                cov_path = ""
-                if _gate_cov is not None:
-                    _gate_cov.stop()
-                    _gate_cov.save()
-                    cov_path = _gate_coverage_file or ""
-                    _gate_cov = None
+                cov_path = _stop_gate_coverage()
                 await protocol.send_message_with_id(
                     writer, "GetCoverageResult", {"path": cov_path},
                     msg_id, write_lock=write_lock,
@@ -1776,10 +1783,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
             # Handle Shutdown synchronously
             if msg_type == "Shutdown":
                 logger.info("Shutdown requested in multiplexed mode")
-                if _gate_cov is not None:
-                    _gate_cov.stop()
-                    _gate_cov.save()
-                    _gate_cov = None
+                _stop_gate_coverage()
                 await protocol.send_message_with_id(
                     writer, "Goodbye", {}, msg_id, write_lock=write_lock,
                 )
@@ -1836,12 +1840,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
         if gate_status_monitor is not None:
             gate_status_monitor.stop()
         # Safety-net: stop coverage if still active (e.g. EOF without Shutdown)
-        if _gate_cov is not None:
-            try:
-                _gate_cov.stop()
-                _gate_cov.save()
-            except Exception:
-                pass
+        _stop_gate_coverage()
 
     return None
 

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -344,7 +344,7 @@ def _stop_gate_coverage() -> str:
     Returns empty string if coverage was not active.
     Resets global state so subsequent calls are no-ops.
     """
-    global _gate_cov
+    global _gate_cov, _gate_coverage_file
     path = ""
     if _gate_cov is not None:
         try:

--- a/src/ftl2/ftl_gate/__main__.py
+++ b/src/ftl2/ftl_gate/__main__.py
@@ -59,6 +59,13 @@ try:
 except ImportError:
     HAS_POLICY = False
 
+# Try to import coverage (bundled into gate .pyz when FTL2_COVERAGE=1)
+try:
+    import coverage as _coverage_mod
+    HAS_COVERAGE = True
+except ImportError:
+    HAS_COVERAGE = False
+
 logger = logging.getLogger("ftl_gate")
 
 
@@ -327,6 +334,8 @@ _last_error: str | None = None
 _start_time: float = 0.0
 _active_tasks: set | None = None
 _draining: bool = False
+_gate_cov: Any = None
+_gate_coverage_file: str | None = None
 
 
 def _module_cache_set(name: str, data: bytes) -> None:
@@ -1106,6 +1115,16 @@ async def main(args: list[str]) -> int | None:
     global _draining
     _draining = False
 
+    # Start coverage collection if enabled
+    global _gate_cov, _gate_coverage_file
+    _gate_cov = None
+    _gate_coverage_file = None
+    if HAS_COVERAGE and os.environ.get("FTL2_COVERAGE") == "1":
+        _gate_coverage_file = f"/tmp/.coverage.gate.{os.getpid()}"
+        _gate_cov = _coverage_mod.Coverage(data_file=_gate_coverage_file)
+        _gate_cov.start()
+        logger.info(f"Coverage started: {_gate_coverage_file}")
+
     # Message processing loop
     while True:
         try:
@@ -1399,11 +1418,27 @@ async def main(args: list[str]) -> int | None:
                     "in_flight": 0,
                 })
 
+            elif msg_type == "GetCoverage":
+                logger.info("GetCoverage requested")
+                cov_path = ""
+                if _gate_cov is not None:
+                    _gate_cov.stop()
+                    _gate_cov.save()
+                    cov_path = _gate_coverage_file or ""
+                    _gate_cov = None
+                await protocol.send_message(
+                    writer, "GetCoverageResult", {"path": cov_path}
+                )
+
             elif msg_type == "Shutdown":
                 logger.info("Shutdown requested")
                 watcher.stop()
                 monitor.stop()
                 gate_status_monitor.stop()
+                if _gate_cov is not None:
+                    _gate_cov.stop()
+                    _gate_cov.save()
+                    _gate_cov = None
                 await protocol.send_message(writer, "Goodbye", {})
                 return None
 
@@ -1703,7 +1738,7 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
 
     # Main reader loop
     tasks = set()
-    global _active_tasks
+    global _active_tasks, _gate_cov, _gate_coverage_file
     _active_tasks = tasks
     draining = False
     try:
@@ -1723,9 +1758,28 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
 
             logger.debug(f"Multiplexed request: {msg_type} msg_id={msg_id}")
 
+            # Handle GetCoverage synchronously
+            if msg_type == "GetCoverage":
+                logger.info("GetCoverage requested in multiplexed mode")
+                cov_path = ""
+                if _gate_cov is not None:
+                    _gate_cov.stop()
+                    _gate_cov.save()
+                    cov_path = _gate_coverage_file or ""
+                    _gate_cov = None
+                await protocol.send_message_with_id(
+                    writer, "GetCoverageResult", {"path": cov_path},
+                    msg_id, write_lock=write_lock,
+                )
+                continue
+
             # Handle Shutdown synchronously
             if msg_type == "Shutdown":
                 logger.info("Shutdown requested in multiplexed mode")
+                if _gate_cov is not None:
+                    _gate_cov.stop()
+                    _gate_cov.save()
+                    _gate_cov = None
                 await protocol.send_message_with_id(
                     writer, "Goodbye", {}, msg_id, write_lock=write_lock,
                 )
@@ -1781,6 +1835,13 @@ async def main_multiplexed(reader, writer, protocol, watcher, monitor, gate_hash
         monitor.stop()
         if gate_status_monitor is not None:
             gate_status_monitor.stop()
+        # Safety-net: stop coverage if still active (e.g. EOF without Shutdown)
+        if _gate_cov is not None:
+            try:
+                _gate_cov.stop()
+                _gate_cov.save()
+            except Exception:
+                pass
 
     return None
 

--- a/src/ftl2/message.py
+++ b/src/ftl2/message.py
@@ -74,6 +74,8 @@ class GateProtocol:
         "GateDrain",  # Request gate to stop accepting new work
         "GateDrainResult",  # Response to GateDrain with completion counts
         "Goodbye",  # Final acknowledgement before gate exit
+        "GetCoverage",  # Request coverage data from gate
+        "GetCoverageResult",  # Response with coverage file path
     }
 
     EVENT_TYPES = {

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -1003,7 +1003,7 @@ class RemoteModuleRunner(ModuleRunner):
         from ftl2.coverage import is_coverage_enabled
 
         cov_enabled = is_coverage_enabled()
-        cov_prefix = "FTL2_COVERAGE=1 " if cov_enabled else ""
+        cov_prefix = "env FTL2_COVERAGE=1 " if cov_enabled else ""
 
         if become and become.effective:
             # Cannot use SSH subsystem with become — always use exec

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -941,10 +941,15 @@ class RemoteModuleRunner(ModuleRunner):
         """
         # Build gate executable
         assert self.gate_builder is not None
+        from ftl2.coverage import is_coverage_enabled
+
+        deps = list(context.execution_config.dependencies)
+        if is_coverage_enabled():
+            deps.append("coverage")
         gate_config = GateBuildConfig(
             modules=context.execution_config.modules,
             module_dirs=context.execution_config.module_dirs,
-            dependencies=context.execution_config.dependencies,
+            dependencies=deps,
             interpreter=interpreter,
         )
         gate_path, gate_hash = self.gate_builder.build(gate_config)
@@ -995,12 +1000,20 @@ class RemoteModuleRunner(ModuleRunner):
             Exception: If gate fails to start or handshake fails
         """
         used_subsystem = False
+        from ftl2.coverage import is_coverage_enabled
+
+        cov_enabled = is_coverage_enabled()
+        cov_prefix = "FTL2_COVERAGE=1 " if cov_enabled else ""
 
         if become and become.effective:
             # Cannot use SSH subsystem with become — always use exec
-            gate_cmd = become.become_prefix(f"{interpreter} {gate_file}")
+            gate_cmd = become.become_prefix(f"{cov_prefix}{interpreter} {gate_file}")
             process = await conn.create_process(gate_cmd, encoding=None)
             logger.info(f"Connected via SSH exec with {become.become_method} (become_user={become.become_user})")
+        elif cov_enabled:
+            # Skip subsystem when coverage enabled — env vars can't be passed via subsystem
+            process = await conn.create_process(f"{cov_prefix}{interpreter} {gate_file}", encoding=None)
+            logger.info("Connected via SSH exec (subsystem skipped for coverage)")
         else:
             # Try SSH subsystem first — no shell startup, no PATH lookup
             try:
@@ -1442,6 +1455,15 @@ class RemoteModuleRunner(ModuleRunner):
         Args:
             gate: Gate connection to close
         """
+        # Retrieve coverage data before shutdown (reader task must be alive)
+        from ftl2.coverage import is_coverage_enabled
+
+        if is_coverage_enabled() and gate.healthy:
+            try:
+                await self._retrieve_gate_coverage(gate)
+            except Exception:
+                logger.debug("Failed to retrieve gate coverage", exc_info=True)
+
         # Mark unhealthy to stop keepalive loop promptly
         gate.healthy = False
 
@@ -1484,6 +1506,38 @@ class RemoteModuleRunner(ModuleRunner):
             pass  # Ignore errors during shutdown
         finally:
             gate.conn.close()
+
+    async def _retrieve_gate_coverage(self, gate: Gate) -> None:
+        """Request coverage data from gate and retrieve via SFTP."""
+        from ftl2.coverage import retrieve_gate_coverage
+
+        if gate.multiplexed:
+            msg_type, data = await self._send_and_wait(
+                gate, "GetCoverage", {}, timeout=30,
+            )
+        else:
+            await self.protocol.send_message(
+                gate.gate_process.stdin, "GetCoverage", {},  # type: ignore[arg-type]
+            )
+            response = await asyncio.wait_for(
+                self.protocol.read_message(gate.gate_process.stdout),  # type: ignore[arg-type]
+                timeout=30,
+            )
+            if response is None:
+                return
+            msg_type, data = response[0], response[1]
+
+        if msg_type != "GetCoverageResult":
+            logger.debug("Unexpected response to GetCoverage: %s", msg_type)
+            return
+
+        remote_path = data.get("path", "") if isinstance(data, dict) else ""
+        if not remote_path:
+            return
+
+        # Use temp_dir basename as host identifier (unique per gate)
+        host_id = gate.temp_dir.rsplit("/", 1)[-1] if gate.temp_dir else "unknown"
+        await retrieve_gate_coverage(gate.conn, remote_path, host_id)
 
     async def close_all(self) -> None:
         """Close all cached gate connections.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,106 @@
+"""Tests for FTL2 production coverage collection (GH-102)."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ftl2.coverage import ControllerCoverage, coverage_dir, is_coverage_enabled
+
+
+class TestIsCoverageEnabled:
+    def test_default_off(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("FTL2_COVERAGE", None)
+            assert not is_coverage_enabled()
+
+    def test_enabled(self):
+        with patch.dict(os.environ, {"FTL2_COVERAGE": "1"}):
+            assert is_coverage_enabled()
+
+    def test_other_values_off(self):
+        for val in ("0", "true", "yes", ""):
+            with patch.dict(os.environ, {"FTL2_COVERAGE": val}):
+                assert not is_coverage_enabled(), f"Expected False for {val!r}"
+
+
+class TestCoverageDir:
+    def test_default_path(self, tmp_path):
+        with patch.dict(os.environ, {"FTL2_COVERAGE_DIR": str(tmp_path / "cov")}):
+            d = coverage_dir()
+            assert d == tmp_path / "cov"
+            assert d.is_dir()
+
+    def test_creates_directory(self, tmp_path):
+        target = tmp_path / "deep" / "nested" / "cov"
+        with patch.dict(os.environ, {"FTL2_COVERAGE_DIR": str(target)}):
+            d = coverage_dir()
+            assert d == target
+            assert d.is_dir()
+
+
+class TestControllerCoverage:
+    def test_no_coverage_installed(self):
+        """ControllerCoverage is a no-op when coverage package is absent."""
+        with patch.dict("sys.modules", {"coverage": None}):
+            with patch("builtins.__import__", side_effect=_make_import_raiser("coverage")):
+                cc = ControllerCoverage()
+                cc.__enter__()
+                assert cc._cov is None
+                cc.__exit__(None, None, None)
+
+    def test_writes_data_file(self, tmp_path):
+        """ControllerCoverage creates a .coverage data file."""
+        pytest.importorskip("coverage")
+        cov_dir = tmp_path / "cov"
+        with patch.dict(os.environ, {"FTL2_COVERAGE_DIR": str(cov_dir)}):
+            with ControllerCoverage():
+                pass  # coverage is running during this block
+            # Data file should exist
+            files = list(cov_dir.glob(".coverage.controller.*"))
+            assert len(files) == 1
+
+
+class TestMessageTypes:
+    def test_coverage_messages_registered(self):
+        from ftl2.message import GateProtocol
+
+        assert "GetCoverage" in GateProtocol.MESSAGE_TYPES
+        assert "GetCoverageResult" in GateProtocol.MESSAGE_TYPES
+
+
+class TestGateBuildDeps:
+    def test_includes_coverage_when_enabled(self):
+        """When FTL2_COVERAGE=1, 'coverage' is added to gate dependencies."""
+        with patch.dict(os.environ, {"FTL2_COVERAGE": "1"}):
+            from ftl2.coverage import is_coverage_enabled
+
+            assert is_coverage_enabled()
+            deps = ["inotify_simple"]
+            if is_coverage_enabled():
+                deps.append("coverage")
+            assert "coverage" in deps
+
+    def test_excludes_coverage_when_disabled(self):
+        """When FTL2_COVERAGE is not set, 'coverage' is not in gate deps."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("FTL2_COVERAGE", None)
+            from ftl2.coverage import is_coverage_enabled
+
+            assert not is_coverage_enabled()
+            deps = ["inotify_simple"]
+            if is_coverage_enabled():
+                deps.append("coverage")
+            assert "coverage" not in deps
+
+
+def _make_import_raiser(blocked_module):
+    """Create an __import__ replacement that raises ImportError for a specific module."""
+    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _import(name, *args, **kwargs):
+        if name == blocked_module:
+            raise ImportError(f"No module named '{blocked_module}'")
+        return real_import(name, *args, **kwargs)
+
+    return _import

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -71,32 +71,35 @@ class TestMessageTypes:
 
 class TestGateBuildDeps:
     def test_includes_coverage_when_enabled(self):
-        """When FTL2_COVERAGE=1, 'coverage' is added to gate dependencies."""
-        with patch.dict(os.environ, {"FTL2_COVERAGE": "1"}):
-            from ftl2.coverage import is_coverage_enabled
+        """When FTL2_COVERAGE=1, gate build config includes coverage dep."""
+        from ftl2.gate import GateBuildConfig
 
-            assert is_coverage_enabled()
-            deps = ["inotify_simple"]
+        base_deps = ["inotify_simple"]
+        with patch.dict(os.environ, {"FTL2_COVERAGE": "1"}):
+            # Simulate what runners._build_and_upload_gate does
+            deps = list(base_deps)
             if is_coverage_enabled():
                 deps.append("coverage")
-            assert "coverage" in deps
+            config = GateBuildConfig(dependencies=deps)
+            assert "coverage" in config.dependencies
 
     def test_excludes_coverage_when_disabled(self):
-        """When FTL2_COVERAGE is not set, 'coverage' is not in gate deps."""
+        """When FTL2_COVERAGE is not set, gate build config omits coverage."""
+        from ftl2.gate import GateBuildConfig
+
+        base_deps = ["inotify_simple"]
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("FTL2_COVERAGE", None)
-            from ftl2.coverage import is_coverage_enabled
-
-            assert not is_coverage_enabled()
-            deps = ["inotify_simple"]
+            deps = list(base_deps)
             if is_coverage_enabled():
                 deps.append("coverage")
-            assert "coverage" not in deps
+            config = GateBuildConfig(dependencies=deps)
+            assert "coverage" not in config.dependencies
 
 
 def _make_import_raiser(blocked_module):
     """Create an __import__ replacement that raises ImportError for a specific module."""
-    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+    real_import = __import__
 
     def _import(name, *args, **kwargs):
         if name == blocked_module:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -16,7 +16,7 @@ class TestGateProtocol:
         assert "Hello" in protocol.MESSAGE_TYPES
         assert "Module" in protocol.MESSAGE_TYPES
         assert "Shutdown" in protocol.MESSAGE_TYPES
-        assert len(protocol.MESSAGE_TYPES) == 32
+        assert len(protocol.MESSAGE_TYPES) == 34
 
     @pytest.mark.asyncio
     async def test_send_message_hello(self):


### PR DESCRIPTION
## Summary

- Adds `FTL2_COVERAGE=1` env var to collect coverage from both controller and remote gate processes
- New `src/ftl2/coverage.py` module following the telemetry pattern (env var check + try/except ImportError + silent no-op)
- Controller side wraps `cli()` with `coverage.Coverage` context manager
- Gate side: bundles coverage.py into zipapp, starts it after gate init, new `GetCoverage`/`GetCoverageResult` protocol messages retrieve `.coverage` file via SFTP before gate shutdown
- Coverage data files written to `~/.ftl/coverage/` (configurable via `FTL2_COVERAGE_DIR`)
- Subsystem mode skipped when coverage enabled (env vars cannot be passed via SSH subsystem)

## Test plan

- [x] 10 new unit tests in `tests/test_coverage.py`
- [x] Full test suite passes (2028 passed, 0 failures)
- [x] Lint clean (ruff)
- [ ] Manual integration: `FTL2_COVERAGE=1 ftl2 run -m command -a "cmd=echo hello" -i hosts.yml`

Closes #102