### PR TITLE
Fix become_user HOME env var (sudo -H)

### DIFF
--- a/src/ftl2/types.py
+++ b/src/ftl2/types.py
@@ -68,8 +68,8 @@ class BecomeConfig:
 
         if method == "sudo":
             if user == "root":
-                return f"sudo -n {cmd}"
-            return f"sudo -n -u {user} {cmd}"
+                return f"sudo -n -H {cmd}"
+            return f"sudo -n -H -u {user} {cmd}"
         elif method == "doas":
             if user == "root":
                 return f"doas -n {cmd}"

--- a/tests/test_become.py
+++ b/tests/test_become.py
@@ -28,16 +28,16 @@ class TestBecomeConfig:
 
     def test_become_prefix_root(self):
         bc = BecomeConfig(become=True)
-        assert bc.become_prefix("whoami") == "sudo -n whoami"
+        assert bc.become_prefix("whoami") == "sudo -n -H whoami"
 
     def test_become_prefix_nonroot_user(self):
         bc = BecomeConfig(become=True, become_user="catbeez")
-        assert bc.become_prefix("whoami") == "sudo -n -u catbeez whoami"
+        assert bc.become_prefix("whoami") == "sudo -n -H -u catbeez whoami"
 
     def test_become_prefix_preserves_command(self):
         bc = BecomeConfig(become=True)
         cmd = "/bin/sh -c 'firewall-cmd --reload'"
-        assert bc.become_prefix(cmd) == f"sudo -n {cmd}"
+        assert bc.become_prefix(cmd) == f"sudo -n -H {cmd}"
 
     def test_become_prefix_doas_root(self):
         bc = BecomeConfig(become=True, become_method="doas")

--- a/tests/test_become_edge_cases.py
+++ b/tests/test_become_edge_cases.py
@@ -12,7 +12,7 @@ class TestBecomeEdgeCases:
         """Deprecated sudo_prefix() still works and returns same result."""
         bc = BecomeConfig(become=True)
         assert bc.sudo_prefix("whoami") == bc.become_prefix("whoami")
-        assert bc.sudo_prefix("whoami") == "sudo -n whoami"
+        assert bc.sudo_prefix("whoami") == "sudo -n -H whoami"
 
     def test_su_single_quote_in_command(self):
         """su -c properly escapes commands containing single quotes via shlex.quote."""
@@ -44,7 +44,7 @@ class TestBecomeEdgeCases:
     def test_empty_command(self):
         """Empty command string doesn't crash."""
         bc = BecomeConfig(become=True)
-        assert bc.become_prefix("") == "sudo -n "
+        assert bc.become_prefix("") == "sudo -n -H "
 
     def test_doas_complex_command(self):
         """doas with a multi-part command."""


### PR DESCRIPTION
## Summary

- Adds `-H` flag to `sudo` invocations in `BecomeConfig.become_prefix()` so `HOME` is set to the target user's home directory
- Updates three test assertions in `test_become.py` to match

Fixes #141

## Test plan

- [x] `tests/test_become.py` -- all 30 tests pass
- [ ] Manual: `become_user="expert"` + `shell(cmd="echo $HOME")` returns `/home/expert`