### PR TITLE
Move gate cache to ~/.local/lib (no root required)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ftl2"
-version = "0.3.3"
+version = "0.3.4"
 description = "Refactored faster-than-light automation framework with dataclasses and composition"
 authors = [{name = "Ben Thomasson", email = "ben.thomasson@gmail.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ftl2"
-version = "0.3.4"
+version = "0.3.5"
 description = "Refactored faster-than-light automation framework with dataclasses and composition"
 authors = [{name = "Ben Thomasson", email = "ben.thomasson@gmail.com"}]
 readme = "README.md"

--- a/src/ftl2/ftl_modules/__init__.py
+++ b/src/ftl2/ftl_modules/__init__.py
@@ -20,7 +20,7 @@ Usage:
 from collections.abc import Callable
 from typing import Any
 
-from ftl2.ftl_modules.aws import ftl_ec2_instance
+from ftl2.ftl_modules.aws import ftl_ec2_instance, ftl_ec2_instance_info
 from ftl2.ftl_modules.command import ftl_command, ftl_shell
 from ftl2.ftl_modules.dnf import ftl_dnf
 from ftl2.ftl_modules.exceptions import (
@@ -59,6 +59,7 @@ FTL_MODULES: dict[str, ModuleFunc] = {
     "dnf5": ftl_dnf,
     "wait_for": ftl_wait_for,
     "ec2_instance": ftl_ec2_instance,
+    "ec2_instance_info": ftl_ec2_instance_info,
 }
 
 # Maps Ansible FQCNs to FTL module functions for compatibility
@@ -77,6 +78,7 @@ ANSIBLE_COMPAT: dict[str, ModuleFunc] = {
     "ansible.builtin.wait_for": ftl_wait_for,
     # AWS modules
     "amazon.aws.ec2_instance": ftl_ec2_instance,
+    "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
 }
 
 
@@ -166,4 +168,5 @@ __all__ = [
     "ftl_wait_for",
     # AWS modules
     "ftl_ec2_instance",
+    "ftl_ec2_instance_info",
 ]

--- a/src/ftl2/ftl_modules/__init__.py
+++ b/src/ftl2/ftl_modules/__init__.py
@@ -20,7 +20,12 @@ Usage:
 from collections.abc import Callable
 from typing import Any
 
-from ftl2.ftl_modules.aws import ftl_ec2_instance, ftl_ec2_instance_info
+from ftl2.ftl_modules.aws import (
+    ftl_ec2_instance,
+    ftl_ec2_instance_info,
+    ftl_route53_info,
+    ftl_route53_record,
+)
 from ftl2.ftl_modules.command import ftl_command, ftl_shell
 from ftl2.ftl_modules.dnf import ftl_dnf
 from ftl2.ftl_modules.exceptions import (
@@ -60,6 +65,8 @@ FTL_MODULES: dict[str, ModuleFunc] = {
     "wait_for": ftl_wait_for,
     "ec2_instance": ftl_ec2_instance,
     "ec2_instance_info": ftl_ec2_instance_info,
+    "route53_record": ftl_route53_record,
+    "route53_info": ftl_route53_info,
 }
 
 # Maps Ansible FQCNs to FTL module functions for compatibility
@@ -79,6 +86,8 @@ ANSIBLE_COMPAT: dict[str, ModuleFunc] = {
     # AWS modules
     "amazon.aws.ec2_instance": ftl_ec2_instance,
     "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
+    "amazon.aws.route53": ftl_route53_record,
+    "amazon.aws.route53_info": ftl_route53_info,
 }
 
 
@@ -169,4 +178,6 @@ __all__ = [
     # AWS modules
     "ftl_ec2_instance",
     "ftl_ec2_instance_info",
+    "ftl_route53_record",
+    "ftl_route53_info",
 ]

--- a/src/ftl2/ftl_modules/aws/__init__.py
+++ b/src/ftl2/ftl_modules/aws/__init__.py
@@ -4,5 +4,11 @@ Async AWS modules using aioboto3 for non-blocking cloud operations.
 """
 
 from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance, ftl_ec2_instance_info
+from ftl2.ftl_modules.aws.route53 import ftl_route53_info, ftl_route53_record
 
-__all__ = ["ftl_ec2_instance", "ftl_ec2_instance_info"]
+__all__ = [
+    "ftl_ec2_instance",
+    "ftl_ec2_instance_info",
+    "ftl_route53_record",
+    "ftl_route53_info",
+]

--- a/src/ftl2/ftl_modules/aws/__init__.py
+++ b/src/ftl2/ftl_modules/aws/__init__.py
@@ -3,6 +3,6 @@
 Async AWS modules using aioboto3 for non-blocking cloud operations.
 """
 
-from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance
+from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance, ftl_ec2_instance_info
 
-__all__ = ["ftl_ec2_instance"]
+__all__ = ["ftl_ec2_instance", "ftl_ec2_instance_info"]

--- a/src/ftl2/ftl_modules/aws/ec2.py
+++ b/src/ftl2/ftl_modules/aws/ec2.py
@@ -5,30 +5,350 @@ Async EC2 instance management using aioboto3.
 
 from typing import Any
 
-from ftl2.ftl_modules.exceptions import requires_extra
+from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
 
-__all__ = ["ftl_ec2_instance"]
+__all__ = ["ftl_ec2_instance", "ftl_ec2_instance_info"]
+
+_RUNNING_STATES = ("running",)
+_STOPPED_STATES = ("stopped",)
+_TERMINATED_STATES = ("terminated", "shutting-down")
+_ACTIVE_STATES = ("pending", "running", "stopping", "stopped")
+
+
+def _extract_instance(instance: dict) -> dict[str, Any]:
+    """Normalize a boto3 instance dict to a flat result."""
+    tags_list = instance.get("Tags") or []
+    tags = {t["Key"]: t["Value"] for t in tags_list}
+    return {
+        "instance_id": instance["InstanceId"],
+        "instance_type": instance.get("InstanceType"),
+        "state": instance["State"]["Name"],
+        "public_ip": instance.get("PublicIpAddress"),
+        "private_ip": instance.get("PrivateIpAddress"),
+        "vpc_id": instance.get("VpcId"),
+        "subnet_id": instance.get("SubnetId"),
+        "image_id": instance.get("ImageId"),
+        "key_name": instance.get("KeyName"),
+        "launch_time": instance.get("LaunchTime", ""),
+        "tags": tags,
+        "security_groups": [
+            {"id": sg["GroupId"], "name": sg["GroupName"]}
+            for sg in instance.get("SecurityGroups", [])
+        ],
+    }
+
+
+async def _find_instance(ec2, instance_id: str | None, name: str | None) -> dict | None:
+    """Find an existing instance by ID or Name tag, skipping terminated."""
+    if instance_id:
+        try:
+            resp = await ec2.describe_instances(InstanceIds=[instance_id])
+        except ec2.exceptions.ClientError:
+            return None
+        for res in resp.get("Reservations", []):
+            for inst in res.get("Instances", []):
+                if inst["State"]["Name"] not in _TERMINATED_STATES:
+                    return inst
+        return None
+
+    if name:
+        resp = await ec2.describe_instances(Filters=[
+            {"Name": "tag:Name", "Values": [name]},
+            {"Name": "instance-state-name", "Values": list(_ACTIVE_STATES)},
+        ])
+        for res in resp.get("Reservations", []):
+            for inst in res.get("Instances", []):
+                return inst
+    return None
+
+
+async def _wait_for_state(ec2, instance_id: str, target: str, timeout: int) -> None:
+    """Wait for an instance to reach a target state."""
+    import asyncio
+
+    waited = 0
+    interval = 5
+    while waited < timeout:
+        resp = await ec2.describe_instances(InstanceIds=[instance_id])
+        state = resp["Reservations"][0]["Instances"][0]["State"]["Name"]
+        if state == target:
+            return
+        await asyncio.sleep(interval)
+        waited += interval
+    raise FTLModuleError(
+        f"Timed out waiting for instance {instance_id} to reach '{target}' "
+        f"after {timeout}s",
+        instance_id=instance_id,
+        target_state=target,
+    )
 
 
 @requires_extra("aws", "aioboto3")
 async def ftl_ec2_instance(
     instance_id: str | None = None,
+    name: str | None = None,
     state: str = "present",
     instance_type: str = "t3.micro",
     image_id: str | None = None,
+    key_name: str | None = None,
+    security_groups: list[str] | None = None,
+    vpc_subnet_id: str | None = None,
+    tags: dict[str, str] | None = None,
+    user_data: str | None = None,
+    wait: bool = True,
+    wait_timeout: int = 600,
+    region: str | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
     """Manage EC2 instances.
 
     Args:
         instance_id: ID of existing instance
-        state: Desired state - present, absent, running, stopped
+        name: Name tag for idempotent instance lookup/creation
+        state: Desired state (present, running, started, stopped, terminated, absent)
         instance_type: EC2 instance type
         image_id: AMI ID for new instances
+        key_name: SSH key pair name
+        security_groups: List of security group IDs
+        vpc_subnet_id: VPC subnet ID
+        tags: Tags to apply (Name tag added automatically from name param)
+        user_data: User data script
+        wait: Wait for state transitions (default True)
+        wait_timeout: Timeout in seconds (default 600)
+        region: AWS region (defaults to AWS_DEFAULT_REGION or profile)
         **kwargs: Additional EC2 parameters
 
     Returns:
-        Result dict with instance_id and changed status
+        Result dict with changed, instance_id, state, and instance details
     """
-    # Placeholder - will be implemented when AWS native modules are built
-    raise NotImplementedError("ftl_ec2_instance is not yet implemented")
+    import aioboto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    state = state.lower()
+    if state == "started":
+        state = "running"
+    if state == "absent":
+        state = "terminated"
+    if state == "present":
+        state = "running"
+
+    session = aioboto3.Session()
+    try:
+        async with session.client("ec2", region_name=region) as ec2:
+            existing = await _find_instance(ec2, instance_id, name)
+
+            if state in ("running",):
+                if existing:
+                    current = existing["State"]["Name"]
+                    if current in _RUNNING_STATES:
+                        return {
+                            "changed": False,
+                            "instance_id": existing["InstanceId"],
+                            "state": current,
+                            "instance": _extract_instance(existing),
+                        }
+                    if current in _STOPPED_STATES:
+                        await ec2.start_instances(
+                            InstanceIds=[existing["InstanceId"]],
+                        )
+                        if wait:
+                            await _wait_for_state(
+                                ec2, existing["InstanceId"], "running", wait_timeout,
+                            )
+                        resp = await ec2.describe_instances(
+                            InstanceIds=[existing["InstanceId"]],
+                        )
+                        inst = resp["Reservations"][0]["Instances"][0]
+                        return {
+                            "changed": True,
+                            "instance_id": inst["InstanceId"],
+                            "state": inst["State"]["Name"],
+                            "instance": _extract_instance(inst),
+                        }
+
+                if not image_id:
+                    raise FTLModuleError(
+                        "image_id is required to create a new instance",
+                    )
+
+                run_params: dict[str, Any] = {
+                    "ImageId": image_id,
+                    "InstanceType": instance_type,
+                    "MinCount": 1,
+                    "MaxCount": 1,
+                }
+                if key_name:
+                    run_params["KeyName"] = key_name
+                if security_groups:
+                    run_params["SecurityGroupIds"] = security_groups
+                if vpc_subnet_id:
+                    run_params["SubnetId"] = vpc_subnet_id
+                if user_data:
+                    run_params["UserData"] = user_data
+
+                all_tags = dict(tags or {})
+                if name:
+                    all_tags["Name"] = name
+                if all_tags:
+                    run_params["TagSpecifications"] = [{
+                        "ResourceType": "instance",
+                        "Tags": [
+                            {"Key": k, "Value": v} for k, v in all_tags.items()
+                        ],
+                    }]
+
+                resp = await ec2.run_instances(**run_params)
+                inst = resp["Instances"][0]
+                new_id = inst["InstanceId"]
+
+                if wait:
+                    await _wait_for_state(ec2, new_id, "running", wait_timeout)
+                    resp = await ec2.describe_instances(InstanceIds=[new_id])
+                    inst = resp["Reservations"][0]["Instances"][0]
+
+                return {
+                    "changed": True,
+                    "instance_id": new_id,
+                    "state": inst["State"]["Name"],
+                    "instance": _extract_instance(inst),
+                }
+
+            elif state == "stopped":
+                if not existing:
+                    raise FTLModuleError(
+                        "Cannot stop instance: no instance found",
+                        instance_id=instance_id,
+                        name=name,
+                    )
+                current = existing["State"]["Name"]
+                if current in _STOPPED_STATES:
+                    return {
+                        "changed": False,
+                        "instance_id": existing["InstanceId"],
+                        "state": current,
+                        "instance": _extract_instance(existing),
+                    }
+                await ec2.stop_instances(InstanceIds=[existing["InstanceId"]])
+                if wait:
+                    await _wait_for_state(
+                        ec2, existing["InstanceId"], "stopped", wait_timeout,
+                    )
+                resp = await ec2.describe_instances(
+                    InstanceIds=[existing["InstanceId"]],
+                )
+                inst = resp["Reservations"][0]["Instances"][0]
+                return {
+                    "changed": True,
+                    "instance_id": inst["InstanceId"],
+                    "state": inst["State"]["Name"],
+                    "instance": _extract_instance(inst),
+                }
+
+            elif state == "terminated":
+                if not existing:
+                    return {
+                        "changed": False,
+                        "instance_id": instance_id,
+                        "state": "terminated",
+                        "instance": None,
+                    }
+                await ec2.terminate_instances(
+                    InstanceIds=[existing["InstanceId"]],
+                )
+                if wait:
+                    await _wait_for_state(
+                        ec2, existing["InstanceId"], "terminated", wait_timeout,
+                    )
+                return {
+                    "changed": True,
+                    "instance_id": existing["InstanceId"],
+                    "state": "terminated",
+                    "instance": _extract_instance(existing),
+                }
+
+            else:
+                raise FTLModuleError(
+                    f"Unsupported state: {state}",
+                    supported_states=["present", "running", "started",
+                                      "stopped", "terminated", "absent"],
+                )
+
+    except FTLModuleError:
+        raise
+    except ClientError as e:
+        raise FTLModuleError(
+            f"AWS API error: {e}",
+            instance_id=instance_id,
+            name=name,
+        ) from e
+    except BotoCoreError as e:
+        raise FTLModuleError(
+            f"AWS connection error: {e}",
+            instance_id=instance_id,
+            name=name,
+        ) from e
+    except Exception as e:
+        raise FTLModuleError(
+            f"EC2 operation failed: {e}",
+            instance_id=instance_id,
+            name=name,
+        ) from e
+
+
+@requires_extra("aws", "aioboto3")
+async def ftl_ec2_instance_info(
+    instance_ids: list[str] | None = None,
+    filters: dict[str, str | list[str]] | None = None,
+    region: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Gather information about EC2 instances.
+
+    Args:
+        instance_ids: List of instance IDs to query
+        filters: EC2 API filters (e.g., {"instance-state-name": "running"})
+        region: AWS region
+        **kwargs: Additional parameters
+
+    Returns:
+        Result dict with instances list
+    """
+    import aioboto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    session = aioboto3.Session()
+    try:
+        async with session.client("ec2", region_name=region) as ec2:
+            params: dict[str, Any] = {}
+            if instance_ids:
+                params["InstanceIds"] = instance_ids
+            if filters:
+                params["Filters"] = [
+                    {"Name": k, "Values": v if isinstance(v, list) else [v]}
+                    for k, v in filters.items()
+                ]
+
+            instances = []
+            paginator = ec2.get_paginator("describe_instances")
+            async for page in paginator.paginate(**params):
+                for res in page.get("Reservations", []):
+                    for inst in res.get("Instances", []):
+                        instances.append(_extract_instance(inst))
+
+            return {
+                "changed": False,
+                "instances": instances,
+            }
+
+    except ClientError as e:
+        raise FTLModuleError(
+            f"AWS API error: {e}",
+        ) from e
+    except BotoCoreError as e:
+        raise FTLModuleError(
+            f"AWS connection error: {e}",
+        ) from e
+    except Exception as e:
+        raise FTLModuleError(
+            f"EC2 query failed: {e}",
+        ) from e

--- a/src/ftl2/ftl_modules/aws/route53.py
+++ b/src/ftl2/ftl_modules/aws/route53.py
@@ -1,0 +1,290 @@
+"""FTL Route 53 module.
+
+Async DNS record management using aioboto3.
+"""
+
+from typing import Any
+
+from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
+
+__all__ = ["ftl_route53_record", "ftl_route53_info"]
+
+
+async def _resolve_zone_id(r53: Any, zone: str) -> str:
+    """Resolve a zone name to a hosted zone ID."""
+    if not zone.endswith("."):
+        zone = zone + "."
+    resp = await r53.list_hosted_zones_by_name(DNSName=zone, MaxItems="1")
+    zones = resp.get("HostedZones", [])
+    if not zones or zones[0]["Name"] != zone:
+        raise FTLModuleError(
+            f"Hosted zone not found: {zone}",
+            zone=zone,
+        )
+    zone_id = zones[0]["Id"]
+    return zone_id.split("/")[-1]
+
+
+def _normalize_record_name(name: str) -> str:
+    """Ensure record name ends with a dot (FQDN)."""
+    if not name.endswith("."):
+        return name + "."
+    return name
+
+
+@requires_extra("aws", "aioboto3")
+async def ftl_route53_record(
+    record: str,
+    type: str = "A",
+    value: str | list[str] | None = None,
+    zone: str | None = None,
+    hosted_zone_id: str | None = None,
+    ttl: int = 300,
+    state: str = "present",
+    wait: bool = False,
+    wait_timeout: int = 120,
+    region: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Manage Route 53 DNS records.
+
+    Args:
+        record: DNS record name (e.g., "myhost.example.com")
+        type: Record type (A, AAAA, CNAME, TXT, MX, etc.)
+        value: Record value(s) — string or list for multiple values
+        zone: Hosted zone name (e.g., "example.com") — resolved to zone ID
+        hosted_zone_id: Hosted zone ID (skip lookup if provided)
+        ttl: TTL in seconds (default 300)
+        state: "present" (UPSERT) or "absent" (DELETE)
+        wait: Wait for change propagation (default False)
+        wait_timeout: Propagation timeout in seconds
+        region: AWS region
+        **kwargs: Additional parameters
+
+    Returns:
+        Result dict with changed, record, type, value, zone_id, change_id
+    """
+    import aioboto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    state = state.lower()
+    if state not in ("present", "absent"):
+        raise FTLModuleError(
+            f"Unsupported state: {state}",
+            supported_states=["present", "absent"],
+        )
+
+    if state == "present" and value is None:
+        raise FTLModuleError("value is required when state=present")
+
+    if not zone and not hosted_zone_id:
+        raise FTLModuleError("Either zone or hosted_zone_id is required")
+
+    values = [value] if isinstance(value, str) else (value or [])
+    record_name = _normalize_record_name(record)
+    record_type = type.upper()
+
+    session = aioboto3.Session()
+    try:
+        async with session.client("route53", region_name=region) as r53:
+            zone_id = hosted_zone_id or await _resolve_zone_id(r53, zone)
+
+            if state == "present":
+                action = "UPSERT"
+                resource_records = [{"Value": v} for v in values]
+            else:
+                action = "DELETE"
+                existing = await _find_record(r53, zone_id, record_name, record_type)
+                if not existing:
+                    return {
+                        "changed": False,
+                        "record": record,
+                        "type": record_type,
+                        "value": values,
+                        "zone_id": zone_id,
+                    }
+                resource_records = existing.get("ResourceRecords", [])
+                ttl = existing.get("TTL", ttl)
+
+            resp = await r53.change_resource_record_sets(
+                HostedZoneId=zone_id,
+                ChangeBatch={
+                    "Changes": [{
+                        "Action": action,
+                        "ResourceRecordSet": {
+                            "Name": record_name,
+                            "Type": record_type,
+                            "TTL": ttl,
+                            "ResourceRecords": resource_records,
+                        },
+                    }],
+                },
+            )
+
+            change_info = resp.get("ChangeInfo", {})
+            change_id = change_info.get("Id", "").split("/")[-1]
+            status = change_info.get("Status", "UNKNOWN")
+
+            if wait and change_id:
+                await _wait_for_change(r53, change_id, wait_timeout)
+                status = "INSYNC"
+
+            return {
+                "changed": True,
+                "record": record,
+                "type": record_type,
+                "value": values,
+                "ttl": ttl,
+                "zone_id": zone_id,
+                "change_id": change_id,
+                "status": status,
+            }
+
+    except FTLModuleError:
+        raise
+    except ClientError as e:
+        raise FTLModuleError(
+            f"AWS API error: {e}",
+            record=record,
+            zone=zone,
+        ) from e
+    except BotoCoreError as e:
+        raise FTLModuleError(
+            f"AWS connection error: {e}",
+            record=record,
+            zone=zone,
+        ) from e
+    except Exception as e:
+        raise FTLModuleError(
+            f"Route 53 operation failed: {e}",
+            record=record,
+            zone=zone,
+        ) from e
+
+
+async def _find_record(
+    r53: Any, zone_id: str, record_name: str, record_type: str,
+) -> dict[str, Any] | None:
+    """Find an existing record set."""
+    resp = await r53.list_resource_record_sets(
+        HostedZoneId=zone_id,
+        StartRecordName=record_name,
+        StartRecordType=record_type,
+        MaxItems="1",
+    )
+    for rr in resp.get("ResourceRecordSets", []):
+        if rr["Name"] == record_name and rr["Type"] == record_type:
+            return rr
+    return None
+
+
+async def _wait_for_change(r53: Any, change_id: str, timeout: int) -> None:
+    """Wait for a Route 53 change to propagate."""
+    import asyncio
+
+    waited = 0
+    interval = 5
+    while waited < timeout:
+        resp = await r53.get_change(Id=change_id)
+        status = resp.get("ChangeInfo", {}).get("Status")
+        if status == "INSYNC":
+            return
+        await asyncio.sleep(interval)
+        waited += interval
+    raise FTLModuleError(
+        f"Timed out waiting for change {change_id} to propagate after {timeout}s",
+        change_id=change_id,
+    )
+
+
+@requires_extra("aws", "aioboto3")
+async def ftl_route53_info(
+    zone: str | None = None,
+    hosted_zone_id: str | None = None,
+    record: str | None = None,
+    type: str | None = None,
+    region: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Query Route 53 DNS records.
+
+    Args:
+        zone: Hosted zone name (e.g., "example.com")
+        hosted_zone_id: Hosted zone ID
+        record: Optional — filter to specific record name
+        type: Optional — filter to specific record type
+        region: AWS region
+        **kwargs: Additional parameters
+
+    Returns:
+        Result dict with records list
+    """
+    import aioboto3
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    if not zone and not hosted_zone_id:
+        raise FTLModuleError("Either zone or hosted_zone_id is required")
+
+    session = aioboto3.Session()
+    try:
+        async with session.client("route53", region_name=region) as r53:
+            zone_id = hosted_zone_id or await _resolve_zone_id(r53, zone)
+
+            params: dict[str, Any] = {"HostedZoneId": zone_id}
+            if record:
+                params["StartRecordName"] = _normalize_record_name(record)
+            if type:
+                params["StartRecordType"] = type.upper()
+
+            records = []
+            while True:
+                resp = await r53.list_resource_record_sets(**params)
+                for rr in resp.get("ResourceRecordSets", []):
+                    entry: dict[str, Any] = {
+                        "name": rr["Name"].rstrip("."),
+                        "type": rr["Type"],
+                        "ttl": rr.get("TTL"),
+                        "values": [r["Value"] for r in rr.get("ResourceRecords", [])],
+                    }
+                    if rr.get("AliasTarget"):
+                        entry["alias"] = {
+                            "dns_name": rr["AliasTarget"]["DNSName"],
+                            "zone_id": rr["AliasTarget"]["HostedZoneId"],
+                            "evaluate_health": rr["AliasTarget"].get(
+                                "EvaluateTargetHealth", False
+                            ),
+                        }
+                    if record and entry["name"] != record.rstrip("."):
+                        continue
+                    if type and entry["type"] != type.upper():
+                        continue
+                    records.append(entry)
+
+                if not resp.get("IsTruncated"):
+                    break
+                params["StartRecordName"] = resp["NextRecordName"]
+                params["StartRecordType"] = resp["NextRecordType"]
+
+            return {
+                "changed": False,
+                "zone_id": zone_id,
+                "records": records,
+            }
+
+    except FTLModuleError:
+        raise
+    except ClientError as e:
+        raise FTLModuleError(
+            f"AWS API error: {e}",
+            zone=zone,
+        ) from e
+    except BotoCoreError as e:
+        raise FTLModuleError(
+            f"AWS connection error: {e}",
+            zone=zone,
+        ) from e
+    except Exception as e:
+        raise FTLModuleError(
+            f"Route 53 query failed: {e}",
+            zone=zone,
+        ) from e

--- a/src/ftl2/ftl_modules/executor.py
+++ b/src/ftl2/ftl_modules/executor.py
@@ -140,7 +140,7 @@ def _get_module(name: str) -> Any:
     circular import issues with the main __init__.py.
     """
     # Import here to avoid circular import
-    from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance
+    from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance, ftl_ec2_instance_info
     from ftl2.ftl_modules.command import ftl_command, ftl_shell
     from ftl2.ftl_modules.dnf import ftl_dnf
     from ftl2.ftl_modules.file import ftl_copy, ftl_file, ftl_template
@@ -160,6 +160,7 @@ def _get_module(name: str) -> Any:
         "pip": ftl_pip,
         "swap": ftl_swap,
         "ec2_instance": ftl_ec2_instance,
+        "ec2_instance_info": ftl_ec2_instance_info,
         "dnf": ftl_dnf,
         "dnf5": ftl_dnf,
         # FQCN mappings
@@ -174,6 +175,7 @@ def _get_module(name: str) -> Any:
         "ansible.builtin.dnf": ftl_dnf,
         "ansible.builtin.dnf5": ftl_dnf,
         "amazon.aws.ec2_instance": ftl_ec2_instance,
+        "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
     }
     return modules.get(name)
 

--- a/src/ftl2/ftl_modules/executor.py
+++ b/src/ftl2/ftl_modules/executor.py
@@ -141,6 +141,7 @@ def _get_module(name: str) -> Any:
     """
     # Import here to avoid circular import
     from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance, ftl_ec2_instance_info
+    from ftl2.ftl_modules.aws.route53 import ftl_route53_info, ftl_route53_record
     from ftl2.ftl_modules.command import ftl_command, ftl_shell
     from ftl2.ftl_modules.dnf import ftl_dnf
     from ftl2.ftl_modules.file import ftl_copy, ftl_file, ftl_template
@@ -161,6 +162,8 @@ def _get_module(name: str) -> Any:
         "swap": ftl_swap,
         "ec2_instance": ftl_ec2_instance,
         "ec2_instance_info": ftl_ec2_instance_info,
+        "route53_record": ftl_route53_record,
+        "route53_info": ftl_route53_info,
         "dnf": ftl_dnf,
         "dnf5": ftl_dnf,
         # FQCN mappings
@@ -176,6 +179,8 @@ def _get_module(name: str) -> Any:
         "ansible.builtin.dnf5": ftl_dnf,
         "amazon.aws.ec2_instance": ftl_ec2_instance,
         "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
+        "amazon.aws.route53": ftl_route53_record,
+        "amazon.aws.route53_info": ftl_route53_info,
     }
     return modules.get(name)
 

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -817,6 +817,8 @@ class RemoteModuleRunner(ModuleRunner):
                 # the file while a gate is running corrupts it.
                 if register_subsystem:
                     await self._register_gate_subsystem(conn, gate_local_path, interpreter)
+                else:
+                    await self._update_gate_stable_path(conn, gate_local_path)
 
                 # Start gate process (subsystem now uses the updated .pyz)
                 gate_process, remote_gate_hash, used_subsystem, supports_multiplex = await self._open_gate(conn, gate_file, interpreter, become=become, host_name=host_name)
@@ -1323,7 +1325,36 @@ class RemoteModuleRunner(ModuleRunner):
             raise ModuleExecutionError(f"Unexpected response type for FTLModule: {msg_type}")
 
     GATE_SUBSYSTEM_PATH = "/usr/local/lib/ftl2/gate.pyz"
+    GATE_USER_PATH = ".local/lib/ftl2/gate.pyz"
     GATE_SUBSYSTEM_NAME = "ftl2-gate"
+
+    async def _update_gate_stable_path(
+        self,
+        conn: SSHClientConnection,
+        gate_local_path: str,
+    ) -> None:
+        """Update the gate binary at a user-writable stable path.
+
+        Uploads the new gate to ~/.local/lib/ftl2/gate.pyz so the next
+        connection can reuse it without re-uploading. No root required.
+
+        Args:
+            conn: Active SSH connection
+            gate_local_path: Local path to the new gate .pyz file
+        """
+        dest = f"$HOME/{self.GATE_USER_PATH}"
+        result = await conn.run(f"echo {dest}", check=True)
+        dest = result.stdout.strip()
+        tmp_dest = dest + ".tmp"
+        try:
+            await conn.run(f"mkdir -p $(dirname {dest})", check=True)
+            async with conn.start_sftp_client() as sftp:
+                await sftp.put(gate_local_path, tmp_dest)
+            await conn.run(f"chmod 755 {tmp_dest}", check=True)
+            await conn.run(f"mv {tmp_dest} {dest}", check=True)
+            logger.info(f"Updated gate at {dest}")
+        except Exception as e:
+            logger.warning(f"Failed to update gate at stable path: {e}")
 
     async def _register_gate_subsystem(
         self,

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -1325,6 +1325,7 @@ class RemoteModuleRunner(ModuleRunner):
             raise ModuleExecutionError(f"Unexpected response type for FTLModule: {msg_type}")
 
     GATE_SUBSYSTEM_PATH = "/usr/local/lib/ftl2/gate.pyz"
+    GATE_USER_PATH = ".local/lib/ftl2/gate.pyz"
     GATE_SUBSYSTEM_NAME = "ftl2-gate"
 
     async def _update_gate_stable_path(
@@ -1332,24 +1333,24 @@ class RemoteModuleRunner(ModuleRunner):
         conn: SSHClientConnection,
         gate_local_path: str,
     ) -> None:
-        """Update the gate binary at the stable subsystem path.
+        """Update the gate binary at a user-writable stable path.
 
-        Uploads the new gate so the next subsystem connection uses it.
-        No sshd reload needed — sshd forks and execs fresh each time.
+        Uploads the new gate to ~/.local/lib/ftl2/gate.pyz so the next
+        connection can reuse it without re-uploading. No root required.
 
         Args:
             conn: Active SSH connection
             gate_local_path: Local path to the new gate .pyz file
         """
-        import os
-        dest = self.GATE_SUBSYSTEM_PATH
+        dest = f"$HOME/{self.GATE_USER_PATH}"
+        result = await conn.run(f"echo {dest}", check=True)
+        dest = result.stdout.strip()
         tmp_dest = dest + ".tmp"
         try:
-            await conn.run(f"mkdir -p {os.path.dirname(dest)}", check=True)
+            await conn.run(f"mkdir -p $(dirname {dest})", check=True)
             async with conn.start_sftp_client() as sftp:
                 await sftp.put(gate_local_path, tmp_dest)
             await conn.run(f"chmod 755 {tmp_dest}", check=True)
-            # Atomic rename — running gate keeps its fd to the old inode
             await conn.run(f"mv {tmp_dest} {dest}", check=True)
             logger.info(f"Updated gate at {dest}")
         except Exception as e:

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -817,8 +817,6 @@ class RemoteModuleRunner(ModuleRunner):
                 # the file while a gate is running corrupts it.
                 if register_subsystem:
                     await self._register_gate_subsystem(conn, gate_local_path, interpreter)
-                else:
-                    await self._update_gate_stable_path(conn, gate_local_path)
 
                 # Start gate process (subsystem now uses the updated .pyz)
                 gate_process, remote_gate_hash, used_subsystem, supports_multiplex = await self._open_gate(conn, gate_file, interpreter, become=become, host_name=host_name)
@@ -1325,36 +1323,7 @@ class RemoteModuleRunner(ModuleRunner):
             raise ModuleExecutionError(f"Unexpected response type for FTLModule: {msg_type}")
 
     GATE_SUBSYSTEM_PATH = "/usr/local/lib/ftl2/gate.pyz"
-    GATE_USER_PATH = ".local/lib/ftl2/gate.pyz"
     GATE_SUBSYSTEM_NAME = "ftl2-gate"
-
-    async def _update_gate_stable_path(
-        self,
-        conn: SSHClientConnection,
-        gate_local_path: str,
-    ) -> None:
-        """Update the gate binary at a user-writable stable path.
-
-        Uploads the new gate to ~/.local/lib/ftl2/gate.pyz so the next
-        connection can reuse it without re-uploading. No root required.
-
-        Args:
-            conn: Active SSH connection
-            gate_local_path: Local path to the new gate .pyz file
-        """
-        dest = f"$HOME/{self.GATE_USER_PATH}"
-        result = await conn.run(f"echo {dest}", check=True)
-        dest = result.stdout.strip()
-        tmp_dest = dest + ".tmp"
-        try:
-            await conn.run(f"mkdir -p $(dirname {dest})", check=True)
-            async with conn.start_sftp_client() as sftp:
-                await sftp.put(gate_local_path, tmp_dest)
-            await conn.run(f"chmod 755 {tmp_dest}", check=True)
-            await conn.run(f"mv {tmp_dest} {dest}", check=True)
-            logger.info(f"Updated gate at {dest}")
-        except Exception as e:
-            logger.warning(f"Failed to update gate at stable path: {e}")
 
     async def _register_gate_subsystem(
         self,


### PR DESCRIPTION
## Summary

- Moves the cached gate .pyz from `/usr/local/lib/ftl2/gate.pyz` to `~/.local/lib/ftl2/gate.pyz`
- Non-root SSH users can now cache the gate without privilege escalation
- Resolves `/Users/ben` at runtime via shell expansion so the path works for any user

## Test plan

- [ ] Deploy to a server as non-root user, verify gate is cached at `~/.local/lib/ftl2/gate.pyz`
- [ ] Verify subsequent connections reuse the cached gate without re-uploading