### PR TITLE
Fix copy ownership under become: default to become_user

### DIFF
--- a/src/ftl2/automation/proxy.py
+++ b/src/ftl2/automation/proxy.py
@@ -460,13 +460,12 @@ class HostScopedProxy:
                     if mode:
                         await ssh.run(become_cfg.become_prefix(f"chmod {mode} {quoted_dest}"))
 
-                    # Set ownership via sudo
-                    if owner and group:
-                        await ssh.run(become_cfg.become_prefix(f"chown {owner}:{group} {quoted_dest}"))
-                    elif owner:
-                        await ssh.run(become_cfg.become_prefix(f"chown {owner} {quoted_dest}"))
-                    elif group:
-                        await ssh.run(become_cfg.become_prefix(f"chgrp {group} {quoted_dest}"))
+                    # Set ownership via sudo — default to become_user when not specified
+                    effective_owner = owner or become_cfg.become_user
+                    effective_group = group or become_cfg.become_user
+                    await ssh.run(become_cfg.become_prefix(
+                        f"chown {effective_owner}:{effective_group} {quoted_dest}"
+                    ))
                 else:
                     # Direct SFTP path (original behavior, no sudo needed)
 


### PR DESCRIPTION
## Summary

- When `become=True` and no explicit `owner`/`group` is specified, the copy method's SFTP-then-sudo-mv path left files owned by the connecting user instead of the become_user
- Now defaults owner/group to `become_cfg.become_user` (typically `root`) so files get correct ownership automatically
- Matches Ansible behavior: files created under become are owned by the become user unless overridden

## Root cause

The become path in `proxy.py`'s `_copy_to_host` writes the file via SFTP (as the connecting user), then `sudo mv`s it to the destination. `mv` preserves original ownership, so the file stays owned by the connecting user. The old code only ran `chown` when owner/group were explicitly provided — when omitted, no ownership fix happened.

## Test plan

- [x] All 2034 existing tests pass (1 pre-existing unrelated failure in test_gate_timeouts excluded)
- [ ] Integration test: deploy with `become=True` as non-root user, verify system files are owned by root

Fixes #145

Generated with [Claude Code](https://claude.com/claude-code)