### PR TITLE
Handle EC2 eventual consistency in _wait_for_state

### DIFF
--- a/src/ftl2/ftl_modules/aws/ec2.py
+++ b/src/ftl2/ftl_modules/aws/ec2.py
@@ -70,11 +70,19 @@ async def _find_instance(ec2, instance_id: str | None, name: str | None) -> dict
 async def _wait_for_state(ec2, instance_id: str, target: str, timeout: int) -> None:
     """Wait for an instance to reach a target state."""
     import asyncio
+    from botocore.exceptions import ClientError
 
     waited = 0
     interval = 5
     while waited < timeout:
-        resp = await ec2.describe_instances(InstanceIds=[instance_id])
+        try:
+            resp = await ec2.describe_instances(InstanceIds=[instance_id])
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+                await asyncio.sleep(interval)
+                waited += interval
+                continue
+            raise
         state = resp["Reservations"][0]["Instances"][0]["State"]["Name"]
         if state == target:
             return


### PR DESCRIPTION
## Summary

- After `run_instances`, the new instance ID may not be immediately visible to `describe_instances` due to AWS eventual consistency
- `_wait_for_state` now retries on `InvalidInstanceID.NotFound` instead of letting it bubble up as a module failure
- This caused deploys to fail on first run but succeed on second run (the instance existed by then)

## Test plan

- [x] All 2034 existing tests pass
- [ ] Deploy from scratch without needing a second run

Generated with [Claude Code](https://claude.com/claude-code)