### PR TITLE
Surface stderr and exit code when gate module fails with no msg

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1728,11 +1728,19 @@ class AutomationContext:
 
             # Convert to ExecuteResult (outside lock — no gate access needed)
             failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
+            if failed:
+                error_msg = result_data.get("msg", "")
+                if not error_msg:
+                    error_msg = result_data.get("stderr", "") or result_data.get("_stderr", "")
+                if not error_msg and result_data.get("rc", 0) != 0:
+                    error_msg = f"exit code {result_data['rc']}"
+            else:
+                error_msg = ""
             return ExecuteResult(
                 success=not failed,
                 changed=result_data.get("changed", False),
                 output=result_data,
-                error=result_data.get("msg", "") if failed else "",
+                error=error_msg,
                 module=module_name,
                 host=host.name,
                 used_ftl=is_ftl_module(module_name),

--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1879,11 +1879,19 @@ class AutomationContext:
                     result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
 
             failed = result_data.get("failed", False) or result_data.get("rc", 0) != 0
+            if failed:
+                error_msg = result_data.get("msg", "")
+                if not error_msg:
+                    error_msg = result_data.get("stderr", "") or result_data.get("_stderr", "")
+                if not error_msg and result_data.get("rc", 0) != 0:
+                    error_msg = f"exit code {result_data['rc']}"
+            else:
+                error_msg = ""
             return ExecuteResult(
                 success=not failed,
                 changed=result_data.get("changed", False),
                 output=result_data,
-                error=result_data.get("msg", "") if failed else "",
+                error=error_msg,
                 module=module_name,
                 host=host.name,
                 used_ftl=is_ftl_module(module_name),


### PR DESCRIPTION
## Summary

- Ansible modules run through the gate can fail with `rc != 0` but no `msg` field, producing empty error messages like `[service] FAILED:`
- Now falls back to `stderr`, then `exit code N` when `msg` is empty
- Gives actionable error output instead of silent failures

## Test plan

- [x] All 2034 existing tests pass
- [ ] Deploy with service module failures — error output should now show the actual reason

Generated with [Claude Code](https://claude.com/claude-code)