### PR TITLE
Handle GateSystemError response type in all code paths

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1635,6 +1635,8 @@ class AutomationContext:
                             result_data = {"failed": True, "msg": f"Gate policy denied: {response[1].get('reason', '')}"}
                         elif response is not None and response[0] == "Error":
                             result_data = {"failed": True, "msg": response[1].get("message", "Unknown FTL module error")}
+                        elif response is not None and response[0] == "GateSystemError":
+                            result_data = {"failed": True, "msg": f"Gate error: {response[1].get('message', 'Unknown')}"}
                         else:
                             result_data = {"failed": True, "msg": f"Unexpected response: {response}"}
 
@@ -1720,6 +1722,8 @@ class AutomationContext:
                             result_data = {"failed": True, "msg": f"Gate policy denied: {data.get('reason', '')}"}
                         elif msg_type == "Error":
                             result_data = {"failed": True, "msg": data.get("message", "Unknown error")}
+                        elif msg_type == "GateSystemError":
+                            result_data = {"failed": True, "msg": f"Gate error: {data.get('message', 'Unknown')}"}
                         else:
                             result_data = {"failed": True, "msg": f"Unexpected response: {msg_type}"}
 
@@ -1734,6 +1738,8 @@ class AutomationContext:
                     error_msg = result_data.get("stderr", "") or result_data.get("_stderr", "")
                 if not error_msg and result_data.get("rc", 0) != 0:
                     error_msg = f"exit code {result_data['rc']}"
+                if not error_msg:
+                    error_msg = str({k: v for k, v in result_data.items() if k not in ("invocation",)})
             else:
                 error_msg = ""
             return ExecuteResult(
@@ -1808,6 +1814,8 @@ class AutomationContext:
                         result_data = {"failed": True, "msg": f"Gate policy denied: {resp_data.get('reason', '')}"}
                     elif resp_type == "Error":
                         result_data = {"failed": True, "msg": resp_data.get("message", "Unknown FTL module error")}
+                    elif resp_type == "GateSystemError":
+                        result_data = {"failed": True, "msg": f"Gate error: {resp_data.get('message', 'Unknown')}"}
                     else:
                         result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
 
@@ -1875,6 +1883,8 @@ class AutomationContext:
                     result_data = {"failed": True, "msg": f"Gate policy denied: {resp_data.get('reason', '')}"}
                 elif resp_type == "Error":
                     result_data = {"failed": True, "msg": resp_data.get("message", "Unknown error")}
+                elif resp_type == "GateSystemError":
+                    result_data = {"failed": True, "msg": f"Gate error: {resp_data.get('message', 'Unknown')}"}
                 else:
                     result_data = {"failed": True, "msg": f"Unexpected response: {resp_type}"}
 
@@ -1885,6 +1895,8 @@ class AutomationContext:
                     error_msg = result_data.get("stderr", "") or result_data.get("_stderr", "")
                 if not error_msg and result_data.get("rc", 0) != 0:
                     error_msg = f"exit code {result_data['rc']}"
+                if not error_msg:
+                    error_msg = str({k: v for k, v in result_data.items() if k not in ("invocation",)})
             else:
                 error_msg = ""
             return ExecuteResult(

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -1122,6 +1122,8 @@ class RemoteModuleRunner(ModuleRunner):
                 )
             elif msg_type == "Error":
                 raise ModuleExecutionError(f"Gate error: {data.get('message', 'Unknown error')}")
+            elif msg_type == "GateSystemError":
+                raise ModuleExecutionError(f"Gate system error: {data.get('message', 'Unknown')}")
             else:
                 raise ModuleExecutionError(f"Unexpected response type: {msg_type}")
 
@@ -1267,6 +1269,8 @@ class RemoteModuleRunner(ModuleRunner):
             )
         elif msg_type == "Error":
             raise ModuleExecutionError(f"Gate error: {data.get('message', 'Unknown error')}")
+        elif msg_type == "GateSystemError":
+            raise ModuleExecutionError(f"Gate system error: {data.get('message', 'Unknown')}")
         else:
             raise ModuleExecutionError(f"Unexpected response type: {msg_type}")
 
@@ -1326,6 +1330,8 @@ class RemoteModuleRunner(ModuleRunner):
             )
         elif msg_type == "Error":
             raise ModuleExecutionError(f"FTL module error: {data.get('message', 'Unknown error')}")
+        elif msg_type == "GateSystemError":
+            raise ModuleExecutionError(f"Gate system error: {data.get('message', 'Unknown')}")
         else:
             raise ModuleExecutionError(f"Unexpected response type for FTLModule: {msg_type}")
 


### PR DESCRIPTION
## Summary
- Handle `GateSystemError` response type in all 7 response-processing locations (4 in context.py, 3 in runners.py)
- Add last-resort error fallback that dumps full `result_data` when no msg/stderr/exit code is available
- Previously, `GateSystemError` fell through to "Unexpected response" with no useful error message

## Test plan
- [x] 2034 tests passed, 8 skipped
- [ ] Deploy to AWS and verify service module failures show actual error content

🤖 Generated with [Claude Code](https://claude.com/claude-code)