### PR TITLE
Fix copy module crash on binary files under become

### DIFF
--- a/src/ftl2/automation/proxy.py
+++ b/src/ftl2/automation/proxy.py
@@ -11,6 +11,7 @@ Supports both simple modules and FQCN (Fully Qualified Collection Name):
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 import warnings
@@ -431,9 +432,10 @@ class HostScopedProxy:
 
                     quoted_dest = _shlex.quote(dest)
 
-                    # Idempotency check via sudo cat (SFTP can't read root-owned files)
-                    stdout, _, rc = await ssh.run(become_cfg.become_prefix(f"cat {quoted_dest}"))
-                    if rc == 0 and stdout.encode() == file_content:
+                    # Idempotency check via hash comparison (cat crashes on binary files)
+                    local_hash = hashlib.sha256(file_content).hexdigest()
+                    stdout, _, rc = await ssh.run(become_cfg.become_prefix(f"sha256sum {quoted_dest}"))
+                    if rc == 0 and stdout.split()[0] == local_hash:
                         changed = False
 
                     if changed:

--- a/src/ftl2/automation/proxy.py
+++ b/src/ftl2/automation/proxy.py
@@ -435,7 +435,8 @@ class HostScopedProxy:
                     # Idempotency check via hash comparison (cat crashes on binary files)
                     local_hash = hashlib.sha256(file_content).hexdigest()
                     stdout, _, rc = await ssh.run(become_cfg.become_prefix(f"sha256sum {quoted_dest}"))
-                    if rc == 0 and stdout.split()[0] == local_hash:
+                    parts = stdout.split()
+                    if rc == 0 and parts and parts[0] == local_hash:
                         changed = False
 
                     if changed:


### PR DESCRIPTION
## Summary
- Replace `sudo cat` with `sudo sha256sum` for idempotency check in copy module become path
- Binary files (e.g. .whl wheels) crash the SSH connection because asyncssh tries to decode stdout as UTF-8
- Hash comparison is binary-safe and more efficient (no file content transmitted)

## Test plan
- [x] 2034 tests passed, 8 skipped
- [ ] Deploy with binary file copy (Python wheel) under become

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)