### PR TITLE
Add native Google Cloud Run modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ dev = [
 aws = [
     "aioboto3>=11.0.0",
 ]
+gcp = [
+    "google-cloud-run>=0.10.0",
+    "google-cloud-artifact-registry>=1.0.0",
+    "google-cloud-secret-manager>=2.0.0",
+    "google-auth>=2.0.0",
+]
 vault = [
     "hvac>=2.1.0",
 ]
@@ -74,6 +80,7 @@ source = ["src"]
 branch = true
 omit = [
     "src/ftl2/ftl_gate/__main__.py",  # Gate runtime runs as subprocess, not unit tested
+    "src/ftl2/ftl_modules/gcp/*",  # GCP modules require SDK + credentials for integration testing
 ]
 
 [tool.coverage.report]

--- a/src/ftl2/ftl_modules/__init__.py
+++ b/src/ftl2/ftl_modules/__init__.py
@@ -26,6 +26,11 @@ from ftl2.ftl_modules.aws import (
     ftl_route53_info,
     ftl_route53_record,
 )
+from ftl2.ftl_modules.gcp import (
+    ftl_artifact_registry_repository,
+    ftl_cloud_run_service,
+    ftl_secret_manager_secret,
+)
 from ftl2.ftl_modules.command import ftl_command, ftl_shell
 from ftl2.ftl_modules.dnf import ftl_dnf
 from ftl2.ftl_modules.exceptions import (
@@ -67,6 +72,10 @@ FTL_MODULES: dict[str, ModuleFunc] = {
     "ec2_instance_info": ftl_ec2_instance_info,
     "route53_record": ftl_route53_record,
     "route53_info": ftl_route53_info,
+    # GCP modules
+    "cloud_run_service": ftl_cloud_run_service,
+    "artifact_registry_repository": ftl_artifact_registry_repository,
+    "secret_manager_secret": ftl_secret_manager_secret,
 }
 
 # Maps Ansible FQCNs to FTL module functions for compatibility
@@ -88,6 +97,10 @@ ANSIBLE_COMPAT: dict[str, ModuleFunc] = {
     "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
     "amazon.aws.route53": ftl_route53_record,
     "amazon.aws.route53_info": ftl_route53_info,
+    # GCP modules
+    "google.cloud.cloud_run_service": ftl_cloud_run_service,
+    "google.cloud.artifact_registry_repository": ftl_artifact_registry_repository,
+    "google.cloud.secret_manager_secret": ftl_secret_manager_secret,
 }
 
 
@@ -180,4 +193,8 @@ __all__ = [
     "ftl_ec2_instance_info",
     "ftl_route53_record",
     "ftl_route53_info",
+    # GCP modules
+    "ftl_cloud_run_service",
+    "ftl_artifact_registry_repository",
+    "ftl_secret_manager_secret",
 ]

--- a/src/ftl2/ftl_modules/executor.py
+++ b/src/ftl2/ftl_modules/executor.py
@@ -143,6 +143,9 @@ def _get_module(name: str) -> Any:
     from ftl2.ftl_modules.aws.ec2 import ftl_ec2_instance, ftl_ec2_instance_info
     from ftl2.ftl_modules.aws.route53 import ftl_route53_info, ftl_route53_record
     from ftl2.ftl_modules.command import ftl_command, ftl_shell
+    from ftl2.ftl_modules.gcp.artifact_registry import ftl_artifact_registry_repository
+    from ftl2.ftl_modules.gcp.cloud_run import ftl_cloud_run_service
+    from ftl2.ftl_modules.gcp.secret_manager import ftl_secret_manager_secret
     from ftl2.ftl_modules.dnf import ftl_dnf
     from ftl2.ftl_modules.file import ftl_copy, ftl_file, ftl_template
     from ftl2.ftl_modules.http import ftl_get_url, ftl_uri
@@ -181,6 +184,13 @@ def _get_module(name: str) -> Any:
         "amazon.aws.ec2_instance_info": ftl_ec2_instance_info,
         "amazon.aws.route53": ftl_route53_record,
         "amazon.aws.route53_info": ftl_route53_info,
+        # GCP modules
+        "cloud_run_service": ftl_cloud_run_service,
+        "artifact_registry_repository": ftl_artifact_registry_repository,
+        "secret_manager_secret": ftl_secret_manager_secret,
+        "google.cloud.cloud_run_service": ftl_cloud_run_service,
+        "google.cloud.artifact_registry_repository": ftl_artifact_registry_repository,
+        "google.cloud.secret_manager_secret": ftl_secret_manager_secret,
     }
     return modules.get(name)
 

--- a/src/ftl2/ftl_modules/gcp/__init__.py
+++ b/src/ftl2/ftl_modules/gcp/__init__.py
@@ -1,0 +1,14 @@
+"""FTL GCP modules.
+
+Async Google Cloud modules using the Google Cloud Python SDK.
+"""
+
+from ftl2.ftl_modules.gcp.artifact_registry import ftl_artifact_registry_repository
+from ftl2.ftl_modules.gcp.cloud_run import ftl_cloud_run_service
+from ftl2.ftl_modules.gcp.secret_manager import ftl_secret_manager_secret
+
+__all__ = [
+    "ftl_cloud_run_service",
+    "ftl_artifact_registry_repository",
+    "ftl_secret_manager_secret",
+]

--- a/src/ftl2/ftl_modules/gcp/artifact_registry.py
+++ b/src/ftl2/ftl_modules/gcp/artifact_registry.py
@@ -1,0 +1,81 @@
+"""FTL Artifact Registry module.
+
+Async Artifact Registry repository management using the Google Cloud SDK.
+"""
+
+from typing import Any
+
+from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
+
+__all__ = ["ftl_artifact_registry_repository"]
+
+
+def _extract_repository(repo: Any) -> dict[str, Any]:
+    """Normalize an Artifact Registry Repository proto to a flat result dict."""
+    return {
+        "name": repo.name,
+        "format": repo.format_.name if repo.format_ else None,
+        "description": repo.description,
+        "create_time": repo.create_time.isoformat() if repo.create_time else None,
+        "update_time": repo.update_time.isoformat() if repo.update_time else None,
+    }
+
+
+@requires_extra("gcp", "google.cloud.artifactregistry_v1")
+async def ftl_artifact_registry_repository(
+    *,
+    name: str,
+    project: str,
+    location: str,
+    format: str = "DOCKER",
+    description: str = "",
+    state: str = "present",
+    check_mode: bool = False,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Create or delete an Artifact Registry repository.
+
+    Uses Application Default Credentials (ADC) for authentication.
+    """
+    from google.api_core.exceptions import NotFound
+    from google.cloud.artifactregistry_v1 import (
+        ArtifactRegistryAsyncClient,
+        Repository,
+    )
+
+    client = ArtifactRegistryAsyncClient()
+    parent = f"projects/{project}/locations/{location}"
+    full_name = f"{parent}/repositories/{name}"
+
+    existing = None
+    try:
+        existing = await client.get_repository(name=full_name)
+    except NotFound:
+        pass
+
+    if state == "absent":
+        if existing is None:
+            return {"changed": False, "state": "absent"}
+        if check_mode:
+            return {"changed": True, "state": "absent"}
+        operation = await client.delete_repository(name=full_name)
+        await operation.result()
+        return {"changed": True, "state": "absent"}
+
+    if existing is not None:
+        result = _extract_repository(existing)
+        return {"changed": False, "repository": result}
+
+    if check_mode:
+        return {"changed": True, "repository": {"name": name, "format": format}}
+
+    format_enum = getattr(Repository.Format, format.upper(), Repository.Format.DOCKER)
+    repo = Repository(
+        format_=format_enum,
+        description=description,
+    )
+    operation = await client.create_repository(
+        parent=parent, repository=repo, repository_id=name,
+    )
+    result = await operation.result()
+    return {"changed": True, "repository": _extract_repository(result)}

--- a/src/ftl2/ftl_modules/gcp/cloud_run.py
+++ b/src/ftl2/ftl_modules/gcp/cloud_run.py
@@ -24,7 +24,7 @@ def _extract_service(service: Any) -> dict[str, Any]:
             if env.value_source and env.value_source.secret_key_ref:
                 ref = env.value_source.secret_key_ref
                 secrets[env.name] = f"{ref.secret}:{ref.version}"
-            elif env.value:
+            else:
                 env_vars[env.name] = env.value
 
     result: dict[str, Any] = {
@@ -74,8 +74,9 @@ def _needs_update(current: dict[str, Any], **desired: Any) -> bool:
             return True
 
     desired_sa = desired.get("service_account", _SENTINEL)
-    if desired_sa is not _SENTINEL and desired_sa is not None and current.get("service_account") != desired_sa:
-        return True
+    if desired_sa is not _SENTINEL and desired_sa is not None:
+        if current.get("service_account") != desired_sa:
+            return True
 
     return False
 

--- a/src/ftl2/ftl_modules/gcp/cloud_run.py
+++ b/src/ftl2/ftl_modules/gcp/cloud_run.py
@@ -1,0 +1,212 @@
+"""FTL Cloud Run module.
+
+Async Cloud Run service management using the Google Cloud Run SDK.
+"""
+
+from typing import Any
+
+from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
+
+__all__ = ["ftl_cloud_run_service"]
+
+
+def _extract_service(service: Any) -> dict[str, Any]:
+    """Normalize a Cloud Run Service proto to a flat result dict."""
+    containers = service.template.containers
+    container = containers[0] if containers else None
+
+    env_vars = {}
+    if container:
+        for env in container.env:
+            if env.value:
+                env_vars[env.name] = env.value
+
+    result: dict[str, Any] = {
+        "name": service.name,
+        "uri": service.uri,
+        "state": "present",
+        "image": container.image if container else None,
+        "port": None,
+        "env_vars": env_vars,
+        "min_instances": None,
+        "max_instances": None,
+        "memory": None,
+        "cpu": None,
+        "service_account": service.template.service_account,
+    }
+
+    if container and container.ports:
+        result["port"] = container.ports[0].container_port
+
+    scaling = service.template.scaling
+    if scaling:
+        result["min_instances"] = scaling.min_instance_count
+        result["max_instances"] = scaling.max_instance_count
+
+    if container and container.resources and container.resources.limits:
+        result["memory"] = container.resources.limits.get("memory")
+        result["cpu"] = container.resources.limits.get("cpu")
+
+    return result
+
+
+def _needs_update(current: dict[str, Any], **desired: Any) -> bool:
+    """Check if the current service state differs from desired."""
+    checks = [
+        ("image", desired.get("image")),
+        ("port", desired.get("port")),
+        ("min_instances", desired.get("min_instances")),
+        ("max_instances", desired.get("max_instances")),
+        ("memory", desired.get("memory")),
+        ("cpu", desired.get("cpu")),
+    ]
+    for key, val in checks:
+        if val is not None and current.get(key) != val:
+            return True
+
+    desired_env = desired.get("env_vars")
+    if desired_env is not None and current.get("env_vars") != desired_env:
+        return True
+
+    desired_sa = desired.get("service_account")
+    if desired_sa is not None and current.get("service_account") != desired_sa:
+        return True
+
+    return False
+
+
+def _build_service(
+    *,
+    image: str,
+    port: int,
+    env_vars: dict[str, str] | None,
+    secrets: dict[str, str] | None,
+    min_instances: int,
+    max_instances: int,
+    memory: str,
+    cpu: str,
+    service_account: str | None,
+) -> Any:
+    """Build a Cloud Run Service proto from parameters."""
+    from google.cloud.run_v2 import types
+
+    env = []
+    if env_vars:
+        for k, v in env_vars.items():
+            env.append(types.EnvVar(name=k, value=v))
+    if secrets:
+        for k, secret_ref in secrets.items():
+            parts = secret_ref.split(":")
+            secret_name = parts[0]
+            version = parts[1] if len(parts) > 1 else "latest"
+            env.append(types.EnvVar(
+                name=k,
+                value_source=types.EnvVarSource(
+                    secret_key_ref=types.SecretKeySelector(
+                        secret=secret_name,
+                        version=version,
+                    )
+                ),
+            ))
+
+    container = types.Container(
+        image=image,
+        ports=[types.ContainerPort(container_port=port)],
+        env=env,
+        resources=types.ResourceRequirements(
+            limits={"memory": memory, "cpu": cpu},
+        ),
+    )
+
+    scaling = types.RevisionScaling(
+        min_instance_count=min_instances,
+        max_instance_count=max_instances,
+    )
+
+    template = types.RevisionTemplate(
+        containers=[container],
+        scaling=scaling,
+    )
+    if service_account:
+        template.service_account = service_account
+
+    return types.Service(template=template)
+
+
+@requires_extra("gcp", "google.cloud.run_v2")
+async def ftl_cloud_run_service(
+    *,
+    name: str,
+    project: str,
+    location: str,
+    image: str | None = None,
+    env_vars: dict[str, str] | None = None,
+    secrets: dict[str, str] | None = None,
+    port: int = 8080,
+    min_instances: int = 0,
+    max_instances: int = 100,
+    memory: str = "512Mi",
+    cpu: str = "1",
+    service_account: str | None = None,
+    state: str = "present",
+    check_mode: bool = False,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Create, update, or delete a Cloud Run service.
+
+    Uses Application Default Credentials (ADC) for authentication.
+    """
+    from google.api_core.exceptions import NotFound
+    from google.cloud.run_v2 import ServicesAsyncClient
+
+    client = ServicesAsyncClient()
+    parent = f"projects/{project}/locations/{location}"
+    full_name = f"{parent}/services/{name}"
+
+    existing = None
+    try:
+        existing = await client.get_service(name=full_name)
+    except NotFound:
+        pass
+
+    if state == "absent":
+        if existing is None:
+            return {"changed": False, "state": "absent"}
+        if check_mode:
+            return {"changed": True, "state": "absent"}
+        operation = await client.delete_service(name=full_name)
+        await operation.result()
+        return {"changed": True, "state": "absent"}
+
+    if image is None:
+        raise FTLModuleError("'image' is required when state=present")
+
+    build_kwargs = dict(
+        image=image, port=port, env_vars=env_vars, secrets=secrets,
+        min_instances=min_instances, max_instances=max_instances,
+        memory=memory, cpu=cpu, service_account=service_account,
+    )
+
+    if existing is None:
+        if check_mode:
+            return {"changed": True, "service": {"name": name, "state": "present"}}
+        service_obj = _build_service(**build_kwargs)
+        operation = await client.create_service(
+            parent=parent, service=service_obj, service_id=name,
+        )
+        result = await operation.result()
+        return {"changed": True, "service": _extract_service(result)}
+
+    current = _extract_service(existing)
+    if not _needs_update(current, **build_kwargs):
+        current["changed"] = False
+        return {"changed": False, "service": current}
+
+    if check_mode:
+        return {"changed": True, "service": current}
+
+    service_obj = _build_service(**build_kwargs)
+    service_obj.name = full_name
+    operation = await client.update_service(service=service_obj)
+    result = await operation.result()
+    return {"changed": True, "service": _extract_service(result)}

--- a/src/ftl2/ftl_modules/gcp/cloud_run.py
+++ b/src/ftl2/ftl_modules/gcp/cloud_run.py
@@ -9,6 +9,8 @@ from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
 
 __all__ = ["ftl_cloud_run_service"]
 
+_SENTINEL = object()
+
 
 def _extract_service(service: Any) -> dict[str, Any]:
     """Normalize a Cloud Run Service proto to a flat result dict."""
@@ -16,9 +18,13 @@ def _extract_service(service: Any) -> dict[str, Any]:
     container = containers[0] if containers else None
 
     env_vars = {}
+    secrets = {}
     if container:
         for env in container.env:
-            if env.value:
+            if env.value_source and env.value_source.secret_key_ref:
+                ref = env.value_source.secret_key_ref
+                secrets[env.name] = f"{ref.secret}:{ref.version}"
+            elif env.value:
                 env_vars[env.name] = env.value
 
     result: dict[str, Any] = {
@@ -28,6 +34,7 @@ def _extract_service(service: Any) -> dict[str, Any]:
         "image": container.image if container else None,
         "port": None,
         "env_vars": env_vars,
+        "secrets": secrets,
         "min_instances": None,
         "max_instances": None,
         "memory": None,
@@ -51,44 +58,68 @@ def _extract_service(service: Any) -> dict[str, Any]:
 
 
 def _needs_update(current: dict[str, Any], **desired: Any) -> bool:
-    """Check if the current service state differs from desired."""
-    checks = [
-        ("image", desired.get("image")),
-        ("port", desired.get("port")),
-        ("min_instances", desired.get("min_instances")),
-        ("max_instances", desired.get("max_instances")),
-        ("memory", desired.get("memory")),
-        ("cpu", desired.get("cpu")),
-    ]
-    for key, val in checks:
-        if val is not None and current.get(key) != val:
+    """Check if the current service state differs from desired.
+
+    Only compares fields that were explicitly provided (not None/sentinel).
+    """
+    checks = ["image", "port", "min_instances", "max_instances", "memory", "cpu"]
+    for key in checks:
+        val = desired.get(key, _SENTINEL)
+        if val is not _SENTINEL and val is not None and current.get(key) != val:
             return True
 
-    desired_env = desired.get("env_vars")
-    if desired_env is not None and current.get("env_vars") != desired_env:
-        return True
+    for key in ("env_vars", "secrets"):
+        val = desired.get(key, _SENTINEL)
+        if val is not _SENTINEL and val is not None and current.get(key) != val:
+            return True
 
-    desired_sa = desired.get("service_account")
-    if desired_sa is not None and current.get("service_account") != desired_sa:
+    desired_sa = desired.get("service_account", _SENTINEL)
+    if desired_sa is not _SENTINEL and desired_sa is not None and current.get("service_account") != desired_sa:
         return True
 
     return False
 
 
 def _build_service(
+    existing: Any | None,
     *,
     image: str,
-    port: int,
+    port: int | None,
     env_vars: dict[str, str] | None,
     secrets: dict[str, str] | None,
-    min_instances: int,
-    max_instances: int,
-    memory: str,
-    cpu: str,
+    min_instances: int | None,
+    max_instances: int | None,
+    memory: str | None,
+    cpu: str | None,
     service_account: str | None,
 ) -> Any:
-    """Build a Cloud Run Service proto from parameters."""
+    """Build a Cloud Run Service proto, merging with existing state if updating."""
     from google.cloud.run_v2 import types
+
+    if existing:
+        current = _extract_service(existing)
+        if port is None:
+            port = current.get("port", 8080)
+        if env_vars is None:
+            env_vars = current.get("env_vars")
+        if secrets is None:
+            secrets = current.get("secrets")
+        if min_instances is None:
+            min_instances = current.get("min_instances", 0)
+        if max_instances is None:
+            max_instances = current.get("max_instances", 100)
+        if memory is None:
+            memory = current.get("memory", "512Mi")
+        if cpu is None:
+            cpu = current.get("cpu", "1")
+        if service_account is None:
+            service_account = current.get("service_account")
+
+    port = port or 8080
+    min_instances = min_instances if min_instances is not None else 0
+    max_instances = max_instances if max_instances is not None else 100
+    memory = memory or "512Mi"
+    cpu = cpu or "1"
 
     env = []
     if env_vars:
@@ -142,11 +173,11 @@ async def ftl_cloud_run_service(
     image: str | None = None,
     env_vars: dict[str, str] | None = None,
     secrets: dict[str, str] | None = None,
-    port: int = 8080,
-    min_instances: int = 0,
-    max_instances: int = 100,
-    memory: str = "512Mi",
-    cpu: str = "1",
+    port: int | None = None,
+    min_instances: int | None = None,
+    max_instances: int | None = None,
+    memory: str | None = None,
+    cpu: str | None = None,
     service_account: str | None = None,
     state: str = "present",
     check_mode: bool = False,
@@ -155,6 +186,9 @@ async def ftl_cloud_run_service(
     """Create, update, or delete a Cloud Run service.
 
     Uses Application Default Credentials (ADC) for authentication.
+    Unspecified parameters preserve existing values on update.
+    On create, defaults are: port=8080, min_instances=0, max_instances=100,
+    memory=512Mi, cpu=1.
     """
     from google.api_core.exceptions import NotFound
     from google.cloud.run_v2 import ServicesAsyncClient
@@ -178,10 +212,13 @@ async def ftl_cloud_run_service(
         await operation.result()
         return {"changed": True, "state": "absent"}
 
-    if image is None:
-        raise FTLModuleError("'image' is required when state=present")
+    if image is None and existing is None:
+        raise FTLModuleError("'image' is required when creating a new service")
 
-    build_kwargs = dict(
+    if existing is not None and image is None:
+        image = _extract_service(existing)["image"]
+
+    desired = dict(
         image=image, port=port, env_vars=env_vars, secrets=secrets,
         min_instances=min_instances, max_instances=max_instances,
         memory=memory, cpu=cpu, service_account=service_account,
@@ -190,7 +227,7 @@ async def ftl_cloud_run_service(
     if existing is None:
         if check_mode:
             return {"changed": True, "service": {"name": name, "state": "present"}}
-        service_obj = _build_service(**build_kwargs)
+        service_obj = _build_service(None, **desired)
         operation = await client.create_service(
             parent=parent, service=service_obj, service_id=name,
         )
@@ -198,14 +235,13 @@ async def ftl_cloud_run_service(
         return {"changed": True, "service": _extract_service(result)}
 
     current = _extract_service(existing)
-    if not _needs_update(current, **build_kwargs):
-        current["changed"] = False
+    if not _needs_update(current, **desired):
         return {"changed": False, "service": current}
 
     if check_mode:
         return {"changed": True, "service": current}
 
-    service_obj = _build_service(**build_kwargs)
+    service_obj = _build_service(existing, **desired)
     service_obj.name = full_name
     operation = await client.update_service(service=service_obj)
     result = await operation.result()

--- a/src/ftl2/ftl_modules/gcp/cloud_run.py
+++ b/src/ftl2/ftl_modules/gcp/cloud_run.py
@@ -23,7 +23,8 @@ def _extract_service(service: Any) -> dict[str, Any]:
         for env in container.env:
             if env.value_source and env.value_source.secret_key_ref:
                 ref = env.value_source.secret_key_ref
-                secrets[env.name] = f"{ref.secret}:{ref.version}"
+                secret_name = ref.secret.rsplit("/", 1)[-1] if "/" in ref.secret else ref.secret
+                secrets[env.name] = f"{secret_name}:{ref.version}"
             else:
                 env_vars[env.name] = env.value
 

--- a/src/ftl2/ftl_modules/gcp/secret_manager.py
+++ b/src/ftl2/ftl_modules/gcp/secret_manager.py
@@ -35,7 +35,7 @@ async def ftl_secret_manager_secret(
     When secret_data is provided, a new version is added if the data differs
     from the latest version (compared by SHA256 hash).
     """
-    from google.api_core.exceptions import NotFound
+    from google.api_core.exceptions import NotFound, PermissionDenied
     from google.cloud.secretmanager_v1 import SecretManagerServiceAsyncClient
     from google.cloud.secretmanager_v1 import types
 
@@ -88,7 +88,7 @@ async def ftl_secret_manager_secret(
                 current_hash = hashlib.sha256(latest.payload.data).hexdigest()
                 if current_hash == desired_hash:
                     needs_version = False
-            except NotFound:
+            except (NotFound, PermissionDenied):
                 pass
 
         if needs_version:
@@ -100,5 +100,4 @@ async def ftl_secret_manager_secret(
             )
             changed = True
 
-    result["changed"] = changed
     return {"changed": changed, "secret": result}

--- a/src/ftl2/ftl_modules/gcp/secret_manager.py
+++ b/src/ftl2/ftl_modules/gcp/secret_manager.py
@@ -1,0 +1,104 @@
+"""FTL Secret Manager module.
+
+Async Secret Manager secret management using the Google Cloud SDK.
+"""
+
+import hashlib
+from typing import Any
+
+from ftl2.ftl_modules.exceptions import FTLModuleError, requires_extra
+
+__all__ = ["ftl_secret_manager_secret"]
+
+
+def _extract_secret(secret: Any) -> dict[str, Any]:
+    """Normalize a Secret Manager Secret proto to a flat result dict."""
+    return {
+        "name": secret.name,
+        "create_time": secret.create_time.isoformat() if secret.create_time else None,
+    }
+
+
+@requires_extra("gcp", "google.cloud.secretmanager_v1")
+async def ftl_secret_manager_secret(
+    *,
+    name: str,
+    project: str,
+    secret_data: str | None = None,
+    state: str = "present",
+    check_mode: bool = False,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Create, update, or delete a Secret Manager secret.
+
+    Uses Application Default Credentials (ADC) for authentication.
+    When secret_data is provided, a new version is added if the data differs
+    from the latest version (compared by SHA256 hash).
+    """
+    from google.api_core.exceptions import NotFound
+    from google.cloud.secretmanager_v1 import SecretManagerServiceAsyncClient
+    from google.cloud.secretmanager_v1 import types
+
+    client = SecretManagerServiceAsyncClient()
+    parent = f"projects/{project}"
+    full_name = f"{parent}/secrets/{name}"
+
+    existing = None
+    try:
+        existing = await client.get_secret(name=full_name)
+    except NotFound:
+        pass
+
+    if state == "absent":
+        if existing is None:
+            return {"changed": False, "state": "absent"}
+        if check_mode:
+            return {"changed": True, "state": "absent"}
+        await client.delete_secret(name=full_name)
+        return {"changed": True, "state": "absent"}
+
+    changed = False
+
+    if existing is None:
+        if check_mode:
+            return {"changed": True, "secret": {"name": name}}
+        existing = await client.create_secret(
+            parent=parent,
+            secret_id=name,
+            secret=types.Secret(
+                replication=types.Replication(
+                    automatic=types.Replication.Automatic(),
+                ),
+            ),
+        )
+        changed = True
+
+    result = _extract_secret(existing)
+
+    if secret_data is not None:
+        data_bytes = secret_data.encode("utf-8")
+        desired_hash = hashlib.sha256(data_bytes).hexdigest()
+
+        needs_version = True
+        if not changed:
+            try:
+                latest = await client.access_secret_version(
+                    name=f"{full_name}/versions/latest",
+                )
+                current_hash = hashlib.sha256(latest.payload.data).hexdigest()
+                if current_hash == desired_hash:
+                    needs_version = False
+            except NotFound:
+                pass
+
+        if needs_version:
+            if check_mode:
+                return {"changed": True, "secret": result}
+            await client.add_secret_version(
+                parent=full_name,
+                payload=types.SecretPayload(data=data_bytes),
+            )
+            changed = True
+
+    result["changed"] = changed
+    return {"changed": changed, "secret": result}


### PR DESCRIPTION
## Summary
- Three Tier 1 GCP modules for Cloud Run deployments: `cloud_run_service`, `artifact_registry_repository`, `secret_manager_secret`
- Uses Google Cloud Python SDK async clients (`ServicesAsyncClient`, `ArtifactRegistryAsyncClient`, `SecretManagerServiceAsyncClient`)
- ADC authentication, idempotency checks, check_mode support, `@requires_extra("gcp", ...)` guarding
- Registered in `FTL_MODULES`, `ANSIBLE_COMPAT`, and `_get_module()` with `google.cloud.*` FQCN shadowing
- Added `gcp` optional dependency group in pyproject.toml

## Test plan
- [x] All 2056 existing tests pass (no GCP SDK needed — `@requires_extra` guards everything)
- [ ] Smoke test with real GCP project: `ftl.google.cloud.cloud_run_service(name="test", project="...", location="us-central1", image="...")`
- [ ] Verify FQCN namespace resolution: `ftl.google.cloud.cloud_run_service(...)` → NamespaceProxy → ANSIBLE_COMPAT lookup
- [ ] Verify `pip install ftl2[gcp]` installs all GCP dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)