### PR TITLE
Add host removal to inventory and automation context

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -957,15 +957,15 @@ class AutomationContext:
         self._hosts_proxy = None
         self._gate_locks.pop(hostname, None)
         self._event_handlers.pop(hostname, None)
-        ssh = self._ssh_connections.pop(hostname, None)
-        if ssh is not None:
-            await ssh.disconnect()
-
         if self._remote_runner:
             for key in list(self._remote_runner.gate_cache.keys()):
                 if key == hostname or key.startswith(f"{hostname}:"):
                     gate = self._remote_runner.gate_cache.pop(key)
                     await self._remote_runner._close_gate(gate)
+
+        ssh = self._ssh_connections.pop(hostname, None)
+        if ssh is not None:
+            await ssh.disconnect()
 
         if self._state is not None:
             self._state.remove_host(hostname)

--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -957,7 +957,9 @@ class AutomationContext:
         self._hosts_proxy = None
         self._gate_locks.pop(hostname, None)
         self._event_handlers.pop(hostname, None)
-        self._ssh_connections.pop(hostname, None)
+        ssh = self._ssh_connections.pop(hostname, None)
+        if ssh is not None:
+            await ssh.disconnect()
 
         if self._remote_runner:
             for key in list(self._remote_runner.gate_cache.keys()):

--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -951,6 +951,23 @@ class AutomationContext:
 
         return host
 
+    async def remove_host(self, hostname: str) -> None:
+        """Remove a host, closing its gate connections and cleaning up all state."""
+        self._inventory.remove_host(hostname)
+        self._hosts_proxy = None
+        self._gate_locks.pop(hostname, None)
+        self._event_handlers.pop(hostname, None)
+        self._ssh_connections.pop(hostname, None)
+
+        if self._remote_runner:
+            for key in list(self._remote_runner.gate_cache.keys()):
+                if key == hostname or key.startswith(f"{hostname}:"):
+                    gate = self._remote_runner.gate_cache.pop(key)
+                    await self._remote_runner._close_gate(gate)
+
+        if self._state is not None:
+            self._state.remove_host(hostname)
+
     @property
     def secrets(self) -> SecretsProxy:
         """Access secrets loaded from environment variables.

--- a/src/ftl2/inventory.py
+++ b/src/ftl2/inventory.py
@@ -48,6 +48,10 @@ class HostGroup:
         """Add a host to this group."""
         self.hosts[host.name] = host
 
+    def remove_host(self, name: str) -> bool:
+        """Remove a host from this group by name. Returns True if found."""
+        return self.hosts.pop(name, None) is not None
+
     def get_host(self, name: str) -> HostConfig | None:
         """Get a host by name."""
         return self.hosts.get(name)
@@ -88,6 +92,14 @@ class Inventory:
     def list_groups(self) -> list[HostGroup]:
         """Get all groups."""
         return list(self.groups.values())
+
+    def remove_host(self, name: str) -> bool:
+        """Remove a host from all groups. Returns True if found in any group."""
+        found = False
+        for group in self.groups.values():
+            if group.remove_host(name):
+                found = True
+        return found
 
     def get_all_hosts(self) -> dict[str, HostConfig]:
         """Get all unique hosts across all groups."""

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -886,6 +886,86 @@ class TestHostScopedProxy:
         assert proxy._target == "minecraft-9"
 
 
+class TestRemoveHost:
+    """Tests for dynamic host removal with remove_host()."""
+
+    @pytest.mark.asyncio
+    async def test_remove_host_from_inventory(self):
+        context = AutomationContext(inventory={
+            "webservers": {
+                "hosts": {
+                    "web01": {"ansible_host": "192.168.1.10"},
+                    "web02": {"ansible_host": "192.168.1.11"},
+                }
+            }
+        })
+
+        await context.remove_host("web01")
+
+        assert "web01" not in context.hosts
+        assert "web02" in context.hosts
+
+    @pytest.mark.asyncio
+    async def test_remove_host_invalidates_proxy_cache(self):
+        context = AutomationContext(inventory={
+            "servers": {
+                "hosts": {
+                    "s1": {"ansible_host": "10.0.0.1"},
+                    "s2": {"ansible_host": "10.0.0.2"},
+                }
+            }
+        })
+
+        _ = context.hosts.all
+        await context.remove_host("s1")
+
+        assert "s1" not in context.hosts
+
+    @pytest.mark.asyncio
+    async def test_remove_host_cleans_up_internal_state(self):
+        context = AutomationContext(inventory={
+            "servers": {
+                "hosts": {
+                    "web01": {"ansible_host": "10.0.0.1"},
+                }
+            }
+        })
+
+        context._gate_locks["web01"] = object()
+        context._event_handlers["web01"] = object()
+
+        await context.remove_host("web01")
+
+        assert "web01" not in context._gate_locks
+        assert "web01" not in context._event_handlers
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_host(self):
+        context = AutomationContext(inventory={
+            "servers": {
+                "hosts": {
+                    "web01": {"ansible_host": "10.0.0.1"},
+                }
+            }
+        })
+
+        await context.remove_host("nonexistent")
+
+        assert "web01" in context.hosts
+
+    @pytest.mark.asyncio
+    async def test_add_then_remove_host(self):
+        context = AutomationContext(inventory={
+            "servers": {"hosts": {}}
+        })
+
+        context.add_host("web01", ansible_host="10.0.0.1", groups=["servers"])
+        assert "web01" in context.hosts
+
+        await context.remove_host("web01")
+        assert "web01" not in context.hosts
+
+
 class TestSecretsManagement:
     """Tests for Phase 3: Secrets Management."""
 

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -175,6 +175,72 @@ class TestInventory:
         assert "shared01" in all_hosts
 
 
+class TestRemoveHost:
+    """Tests for removing hosts from groups and inventory."""
+
+    def test_remove_host_from_group(self):
+        group = HostGroup(name="webservers")
+        host = HostConfig(name="web01", ansible_host="192.168.1.10")
+        group.add_host(host)
+
+        assert group.remove_host("web01") is True
+        assert group.get_host("web01") is None
+        assert len(group.hosts) == 0
+
+    def test_remove_host_from_group_not_found(self):
+        group = HostGroup(name="webservers")
+
+        assert group.remove_host("nonexistent") is False
+
+    def test_remove_host_from_inventory_single_group(self):
+        inventory = Inventory()
+        group = HostGroup(name="webservers")
+        host = HostConfig(name="web01", ansible_host="192.168.1.10")
+        group.add_host(host)
+        inventory.add_group(group)
+
+        assert inventory.remove_host("web01") is True
+        assert "web01" not in inventory.get_all_hosts()
+
+    def test_remove_host_from_inventory_multiple_groups(self):
+        inventory = Inventory()
+        host = HostConfig(name="shared", ansible_host="192.168.1.50")
+
+        group1 = HostGroup(name="web")
+        group1.add_host(host)
+        group2 = HostGroup(name="app")
+        group2.add_host(host)
+
+        inventory.add_group(group1)
+        inventory.add_group(group2)
+
+        assert inventory.remove_host("shared") is True
+        assert group1.get_host("shared") is None
+        assert group2.get_host("shared") is None
+        assert "shared" not in inventory.get_all_hosts()
+
+    def test_remove_host_from_inventory_not_found(self):
+        inventory = Inventory()
+        group = HostGroup(name="webservers")
+        inventory.add_group(group)
+
+        assert inventory.remove_host("nonexistent") is False
+
+    def test_remove_host_leaves_other_hosts(self):
+        inventory = Inventory()
+        group = HostGroup(name="webservers")
+        host1 = HostConfig(name="web01", ansible_host="192.168.1.10")
+        host2 = HostConfig(name="web02", ansible_host="192.168.1.11")
+        group.add_host(host1)
+        group.add_host(host2)
+        inventory.add_group(group)
+
+        inventory.remove_host("web01")
+
+        assert "web01" not in inventory.get_all_hosts()
+        assert "web02" in inventory.get_all_hosts()
+
+
 class TestLoadInventory:
     """Tests for load_inventory function."""
 


### PR DESCRIPTION
## Summary
- Add remove_host to Inventory and HostGroup for removing hosts from all groups
- Add remove_host to AutomationContext with full cleanup: gate connections, SSH state, event handlers, locks, and host state tracking
- Supports dynamic host management at runtime (e.g., scaling down infrastructure)

## Test plan
- [ ] Verify host removal cleans up gate connections properly
- [ ] Verify host is removed from all groups in inventory
- [ ] Verify state tracking is updated after removal
- [ ] Test removing a host that does not exist (no-op behavior)