### PR TITLE
Mark dead gates unhealthy so controlplane can reconnect

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1740,7 +1740,11 @@ class AutomationContext:
             # Fast path: multiplexed gate already in cache — no lock needed
             cached_gate = self._remote_runner.gate_cache.get(cache_key)
             if cached_gate and cached_gate.multiplexed:
-                return await self._execute_multiplexed(cached_gate, host, module_name, params)
+                if not cached_gate.healthy:
+                    self._remote_runner.gate_cache.pop(cache_key, None)
+                    await self._remote_runner._close_gate(cached_gate)
+                else:
+                    return await self._execute_multiplexed(cached_gate, host, module_name, params)
 
             # Serial path: lock to prevent redundant SSH connections
             async with self._gate_lock(cache_key):
@@ -2107,13 +2111,14 @@ class AutomationContext:
         else:
             interpreter = host.ansible_python_interpreter or "/usr/bin/python3"
 
-        # Check cache — verify interpreter matches
+        # Check cache — verify health and interpreter match
         cache_key = gate_cache_key(host.name, become)
         if cache_key in self._remote_runner.gate_cache:
             gate = self._remote_runner.gate_cache[cache_key]
-            if gate.interpreter == interpreter:
-                # Multiplexed gates stay in cache (shared access).
-                # Serial gates are popped (exclusive access).
+            if not gate.healthy:
+                self._remote_runner.gate_cache.pop(cache_key)
+                await self._remote_runner._close_gate(gate)
+            elif gate.interpreter == interpreter:
                 if not gate.multiplexed:
                     self._remote_runner.gate_cache.pop(cache_key)
                 return gate

--- a/src/ftl2/runners.py
+++ b/src/ftl2/runners.py
@@ -151,7 +151,8 @@ async def _gate_reader_loop(
         while True:
             msg = await protocol.read_message(gate.gate_process.stdout)
             if msg is None:
-                # EOF — fail all pending
+                # EOF — mark unhealthy and fail all pending
+                gate.healthy = False
                 for future in gate._pending.values():
                     if not future.done():
                         future.set_exception(
@@ -179,6 +180,7 @@ async def _gate_reader_loop(
         return
     except Exception as e:
         logger.error(f"Gate reader error: {e}")
+        gate.healthy = False
         for future in gate._pending.values():
             if not future.done():
                 future.set_exception(e)
@@ -1215,7 +1217,8 @@ class RemoteModuleRunner(ModuleRunner):
                         pass
                     break
                 except (ConnectionError, BrokenPipeError, OSError):
-                    # Connection already dead, reader loop will handle cleanup
+                    gate.healthy = False
+                    self.gate_cache.pop(cache_key, None)
                     break
         except asyncio.CancelledError:
             return

--- a/tests/test_gate_timeouts.py
+++ b/tests/test_gate_timeouts.py
@@ -310,13 +310,15 @@ class TestKeepaliveLoop:
         assert len(gate._pending) == 0
 
     @pytest.mark.asyncio
-    async def test_keepalive_connection_error_exits_cleanly(self):
-        """Keepalive loop exits on BrokenPipeError without marking unhealthy."""
+    async def test_keepalive_connection_error_marks_unhealthy(self):
+        """Keepalive loop marks gate unhealthy and evicts on BrokenPipeError."""
         runner = RemoteModuleRunner()
         runner.KEEPALIVE_INTERVAL = 0.02
         runner.KEEPALIVE_TIMEOUT = 5.0
 
         gate = _make_gate()
+        cache_key = "test:22:user"
+        runner.gate_cache[cache_key] = gate
 
         # _send_and_wait raises a transport error
         async def broken_send(gate, msg_type, data, timeout=None):
@@ -324,10 +326,11 @@ class TestKeepaliveLoop:
 
         with patch.object(runner, "_send_and_wait", side_effect=broken_send):
             await asyncio.wait_for(
-                runner._keepalive_loop(gate, "test:22:user"),
+                runner._keepalive_loop(gate, cache_key),
                 timeout=1.0,
             )
-        # The loop breaks on connection errors — reader loop handles cleanup
+        assert not gate.healthy
+        assert cache_key not in runner.gate_cache
 
 
 class TestUnhealthyGateEviction:


### PR DESCRIPTION
## Summary

Fixes benthomasson/ftl2-controlplane#18 -- after a connection reset (e.g. network interruption overnight), the gate reader loop detected the error but never set gate.healthy = False. The controlplane health check saw healthy=True and skipped reconnection, leaving the gate as a zombie: cached, flagged healthy, completely dead. Commands failed with 'Channel not open for sending' / exit code 255.

Four fixes:
- **_gate_reader_loop**: set gate.healthy = False on both EOF and exception exit paths
- **_keepalive_loop**: BrokenPipeError handler now marks unhealthy and evicts from cache instead of delegating to the reader loop (which never did the cleanup)
- **_execute_remote_via_gate**: multiplexed fast path checks cached_gate.healthy before use; evicts unhealthy gates
- **_get_or_create_gate**: checks gate.healthy before returning cached gate, matching the runners.py version

## Test plan

- [ ] Existing tests pass (99 passed)
- [ ] Start controlplane, connect to a host, verify commands work
- [ ] Kill the SSH connection and verify the health check detects the dead gate and reconnects within 30s