### PR TITLE
Fix gate exit code lost when parsing module result

### DIFF
--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1828,8 +1828,11 @@ class AutomationContext:
                             # Parse the stdout as JSON (Ansible module output)
                             stdout = data.get("stdout", "")
                             stderr = data.get("stderr", "")
+                            gate_rc = data.get("rc", 0)
                             try:
                                 result_data = json.loads(stdout) if stdout.strip() else {}
+                                if "rc" not in result_data:
+                                    result_data["rc"] = gate_rc
                                 if stderr:
                                     result_data["_stderr"] = stderr
                                 if not result_data:
@@ -1991,8 +1994,11 @@ class AutomationContext:
                 if resp_type == "ModuleResult":
                     stdout = resp_data.get("stdout", "")
                     stderr = resp_data.get("stderr", "")
+                    gate_rc = resp_data.get("rc", 0)
                     try:
                         result_data = json.loads(stdout) if stdout.strip() else {}
+                        if "rc" not in result_data:
+                            result_data["rc"] = gate_rc
                         if stderr:
                             result_data["_stderr"] = stderr
                         if not result_data:

--- a/src/ftl2/automation/context.py
+++ b/src/ftl2/automation/context.py
@@ -1831,8 +1831,6 @@ class AutomationContext:
                             gate_rc = data.get("rc", 0)
                             try:
                                 result_data = json.loads(stdout) if stdout.strip() else {}
-                                if "rc" not in result_data:
-                                    result_data["rc"] = gate_rc
                                 if stderr:
                                     result_data["_stderr"] = stderr
                                 if not result_data:
@@ -1845,6 +1843,8 @@ class AutomationContext:
                                 if stderr and "Traceback" in stderr and not result_data.get("failed"):
                                     result_data["failed"] = True
                                     result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
+                                if "rc" not in result_data:
+                                    result_data["rc"] = gate_rc
                             except json.JSONDecodeError as e:
                                 result_data = {
                                     "failed": True,
@@ -1997,8 +1997,6 @@ class AutomationContext:
                     gate_rc = resp_data.get("rc", 0)
                     try:
                         result_data = json.loads(stdout) if stdout.strip() else {}
-                        if "rc" not in result_data:
-                            result_data["rc"] = gate_rc
                         if stderr:
                             result_data["_stderr"] = stderr
                         if not result_data:
@@ -2009,6 +2007,8 @@ class AutomationContext:
                         if stderr and "Traceback" in stderr and not result_data.get("failed"):
                             result_data["failed"] = True
                             result_data["msg"] = f"Module crashed: {stderr.strip().splitlines()[-1]}"
+                        if "rc" not in result_data:
+                            result_data["rc"] = gate_rc
                     except json.JSONDecodeError as e:
                         result_data = {
                             "failed": True,

--- a/tests/test_context_error_handling.py
+++ b/tests/test_context_error_handling.py
@@ -281,6 +281,174 @@ class TestMultiplexedPathErrorHandling:
         assert "Pipe broken" in result.error
 
 
+class TestGateExitCodePropagation:
+    """Gate subprocess exit codes are carried into ExecuteResult."""
+
+    def _serial_gate(self):
+        gate = MagicMock()
+        gate.multiplexed = False
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate.gate_process.stdout = MagicMock()
+        return gate
+
+    def _mux_gate(self, resp):
+        gate = MagicMock()
+        gate.multiplexed = True
+        gate.gate_process = MagicMock()
+        gate.gate_process.stdin = MagicMock()
+        gate._write_lock = asyncio.Lock()
+        gate.next_msg_id.return_value = 1
+
+        f = asyncio.get_running_loop().create_future()
+        f.set_result(resp)
+        gate.create_future.return_value = f
+        return gate
+
+    @pytest.mark.asyncio
+    async def test_serial_nonzero_rc_reports_failure(self):
+        """Non-zero gate rc surfaces as failed ExecuteResult."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+        gate = self._serial_gate()
+
+        module_json = '{"changed": false}'
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate), patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message', new_callable=AsyncMock,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'read_message', new_callable=AsyncMock,
+            return_value=("ModuleResult", {"stdout": module_json, "stderr": "", "rc": 1}),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "command", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert result.output["rc"] == 1
+
+    @pytest.mark.asyncio
+    async def test_serial_zero_rc_reports_success(self):
+        """Zero gate rc with valid JSON reports success."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+        gate = self._serial_gate()
+
+        module_json = '{"changed": true}'
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate), patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message', new_callable=AsyncMock,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'read_message', new_callable=AsyncMock,
+            return_value=("ModuleResult", {"stdout": module_json, "stderr": "", "rc": 0}),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "file", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is True
+        assert result.output["rc"] == 0
+
+    @pytest.mark.asyncio
+    async def test_serial_module_rc_preserved_over_gate_rc(self):
+        """Module JSON with its own rc takes precedence over gate rc."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+        gate = self._serial_gate()
+
+        module_json = '{"changed": false, "rc": 2}'
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate), patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message', new_callable=AsyncMock,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'read_message', new_callable=AsyncMock,
+            return_value=("ModuleResult", {"stdout": module_json, "stderr": "", "rc": 0}),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "command", {})
+
+        assert result.success is False
+        assert result.output["rc"] == 2
+
+    @pytest.mark.asyncio
+    async def test_serial_empty_stdout_still_fails(self):
+        """Empty stdout with non-zero rc still reports failure."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+        gate = self._serial_gate()
+
+        with patch.object(ctx, '_get_or_create_gate', return_value=gate), patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message', new_callable=AsyncMock,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'read_message', new_callable=AsyncMock,
+            return_value=("ModuleResult", {"stdout": "", "stderr": "permission denied", "rc": 1}),
+        ):
+            result = await ctx._execute_remote_via_gate(host, "command", {})
+
+        assert result.success is False
+        assert result.output["rc"] == 1
+
+    @pytest.mark.asyncio
+    async def test_multiplexed_nonzero_rc_reports_failure(self):
+        """Non-zero gate rc in multiplexed path surfaces as failure."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        module_json = '{"changed": false}'
+        gate = self._mux_gate(("ModuleResult", {"stdout": module_json, "stderr": "", "rc": 1}))
+
+        with patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id', new_callable=AsyncMock,
+        ):
+            result = await ctx._execute_multiplexed(gate, host, "command", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is False
+        assert result.output["rc"] == 1
+
+    @pytest.mark.asyncio
+    async def test_multiplexed_zero_rc_reports_success(self):
+        """Zero gate rc in multiplexed path reports success."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        module_json = '{"changed": true}'
+        gate = self._mux_gate(("ModuleResult", {"stdout": module_json, "stderr": "", "rc": 0}))
+
+        with patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id', new_callable=AsyncMock,
+        ):
+            result = await ctx._execute_multiplexed(gate, host, "file", {})
+
+        assert isinstance(result, ExecuteResult)
+        assert result.success is True
+        assert result.output["rc"] == 0
+
+    @pytest.mark.asyncio
+    async def test_multiplexed_empty_stdout_still_fails(self):
+        """Empty stdout in multiplexed path with non-zero rc still reports failure."""
+        ctx = _make_context_with_mocks()
+        host = _make_host()
+
+        gate = self._mux_gate(("ModuleResult", {"stdout": "", "stderr": "error", "rc": 1}))
+
+        with patch(
+            'ftl2.ftl_modules.executor.is_ftl_module', return_value=False,
+        ), patch.object(
+            ctx._remote_runner.protocol, 'send_message_with_id', new_callable=AsyncMock,
+        ):
+            result = await ctx._execute_multiplexed(gate, host, "command", {})
+
+        assert result.success is False
+        assert result.output["rc"] == 1
+
+
 class TestErrorDataContract:
     """Both paths honour the errors-as-data contract for all exception types."""
 


### PR DESCRIPTION
## Summary
- The _execute_remote_via_gate and _execute_multiplexed paths parsed module stdout JSON into result_data, discarding the gate-level rc field
- If the module's JSON output didn't include its own rc key (most don't), the subprocess exit code was silently lost and reported as success
- Now the gate's rc is carried into result_data when the parsed module output doesn't already contain one, matching RemoteModuleRunner's behavior

## Root cause
The gate sends back `{"stdout": "...", "stderr": "...", "rc": 1}`. The controller did `result_data = json.loads(stdout)`, replacing the gate-level dict with the parsed module output (which typically has no `rc` key). The subsequent `result_data.get("rc", 0)` then defaulted to 0 — success.

## Test plan
- [ ] Verify with become_user running a command that exits non-zero — should now report failure
- [ ] Verify modules that include their own rc in stdout JSON still use the module's rc (not overwritten)
- [ ] Existing test suite passes (174 tests confirmed)