### PR TITLE
Fix become_user not changing CWD to target user home

### DIFF
--- a/src/ftl2/types.py
+++ b/src/ftl2/types.py
@@ -69,7 +69,7 @@ class BecomeConfig:
         if method == "sudo":
             if user == "root":
                 return f"sudo -n -H {cmd}"
-            return f"sudo -n -H -u {user} {cmd}"
+            return f"sudo -n -H -u {user} sh -c {shlex.quote('cd ~ && ' + cmd)}"
         elif method == "doas":
             if user == "root":
                 return f"doas -n {cmd}"

--- a/tests/test_become.py
+++ b/tests/test_become.py
@@ -32,7 +32,7 @@ class TestBecomeConfig:
 
     def test_become_prefix_nonroot_user(self):
         bc = BecomeConfig(become=True, become_user="catbeez")
-        assert bc.become_prefix("whoami") == "sudo -n -H -u catbeez whoami"
+        assert bc.become_prefix("whoami") == "sudo -n -H -u catbeez sh -c 'cd ~ && whoami'"
 
     def test_become_prefix_preserves_command(self):
         bc = BecomeConfig(become=True)


### PR DESCRIPTION
Closes #171

## Summary
- `sudo -n -H -u <user>` sets `HOME` but leaves CWD unchanged, causing tools like `uv` to read config from the wrong home directory
- Non-root sudo commands are now wrapped with `sh -c 'cd ~ && CMD'` so CWD matches the target user's home
- Root sudo is unchanged (already runs as root in root's context

## Test plan
- [x]  updated and passing
- [x] All 30 become tests pass
- [ ] Integration test:  should run commands in 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)