### PR TITLE
Fix shell module non-zero exit code not reported as failure

### DIFF
--- a/src/ftl2/automation/proxy.py
+++ b/src/ftl2/automation/proxy.py
@@ -283,7 +283,7 @@ class HostScopedProxy:
 
         duration = time.time() - start_time
         exec_result = ExecuteResult(
-            success=not result.get("failed", False),
+            success=not (result.get("failed", False) or result.get("rc", 0) != 0),
             changed=result.get("changed", False),
             output=result,
             module=module_name,

--- a/tests/test_native_file_transfer.py
+++ b/tests/test_native_file_transfer.py
@@ -484,6 +484,34 @@ class TestNativeShell:
         assert result["rc"] == 42
 
     @pytest.mark.asyncio
+    async def test_shell_nonzero_rc_tracked_as_failure(self, mock_context):
+        """Non-zero rc is tracked as success=False in the results pipeline."""
+        mock_context._results = []
+        mock_context.verbose = False
+        mock_context.quiet = True
+        proxy = HostScopedProxy(mock_context, "localhost")
+
+        await proxy.shell(cmd="exit 1")
+
+        assert len(mock_context._results) == 1
+        assert mock_context._results[0].success is False
+        assert mock_context._results[0].output["rc"] == 1
+
+    @pytest.mark.asyncio
+    async def test_shell_zero_rc_tracked_as_success(self, mock_context):
+        """Zero rc is tracked as success=True in the results pipeline."""
+        mock_context._results = []
+        mock_context.verbose = False
+        mock_context.quiet = True
+        proxy = HostScopedProxy(mock_context, "localhost")
+
+        await proxy.shell(cmd="echo ok")
+
+        assert len(mock_context._results) == 1
+        assert mock_context._results[0].success is True
+        assert mock_context._results[0].output["rc"] == 0
+
+    @pytest.mark.asyncio
     async def test_shell_captures_stderr(self, mock_context):
         """shell() captures stderr output."""
         proxy = HostScopedProxy(mock_context, "localhost")


### PR DESCRIPTION
## Summary
- `_track_result()` in `proxy.py` only checked `result["failed"]` to determine `success`, ignoring `result["rc"]`
- Shell commands exiting non-zero were tracked as `success=True`, so `ftl.failed` and `ftl.errors` never detected them
- Fixed by checking both `"failed"` and `"rc"`, matching the pattern already used in `_execute_remote_via_gate` (context.py:1901) and `ExecuteResult.from_module_output` (executor.py:61)

## The bug
```python
# Before (proxy.py:286)
success=not result.get("failed", False)           # ignores rc

# After
success=not (result.get("failed", False) or result.get("rc", 0) != 0)
```

## Test plan
- [x] New test: non-zero rc tracked as `success=False` in results pipeline
- [x] New test: zero rc tracked as `success=True` in results pipeline
- [x] All 15 shell tests pass

Generated with [Claude Code](https://claude.com/claude-code)