### PR TITLE
Add --all-modules and --output flags to ftl-gate-builder

### DIFF
--- a/src/ftl2/builder.py
+++ b/src/ftl2/builder.py
@@ -83,6 +83,7 @@ def main(
             click.echo(f"Loaded {len(file_modules)} modules from {from_modules_file}")
 
     if all_modules:
+        count_before = len(modules)
         builtin_modules_dir = Path(__file__).parent / "modules"
         for p in sorted(builtin_modules_dir.glob("*.py")):
             if not p.name.startswith("_"):
@@ -90,7 +91,7 @@ def main(
         from ftl2.ftl_modules.executor import _FTL_MODULE_FILES
         for name in _FTL_MODULE_FILES:
             modules.append(name)
-        click.echo(f"Auto-discovered {len(modules)} modules (--all-modules)")
+        click.echo(f"Auto-discovered {len(modules) - count_before} modules (--all-modules)")
 
     if not modules:
         raise click.ClickException("No modules specified. Use -m, -f, or --all-modules.")

--- a/src/ftl2/builder.py
+++ b/src/ftl2/builder.py
@@ -9,16 +9,19 @@ Usage:
 
 Options:
     -m, --module            Module to include (can be specified multiple times)
+    -A, --all-modules       Include all built-in gate and FTL modules
     -f, --from-modules-file Read module names from file (one per line)
     -M, --module-dir        Module directory to search (can be specified multiple times)
     -r, --requirements      Python requirements file (can be specified multiple times)
     -I, --interpreter       Python interpreter for target system (default: /usr/bin/python3)
+    -o, --output            Copy built gate to this path
     -c, --cache-dir         Cache directory for built gates (default: ~/.ftl)
     -v, --verbose           Show verbose logging
     -d, --debug             Show debug logging
 
 Examples:
     ftl-gate-builder -m ping -m setup -M /opt/modules
+    ftl-gate-builder --all-modules -o gate.pyz
     ftl-gate-builder -f .ftl2-modules.txt
     ftl-gate-builder -f .ftl2-modules.txt -m extra_module -r requirements.txt
     ftl-gate-builder -m module -I /opt/python3.9/bin/python --debug
@@ -37,19 +40,23 @@ logger = logging.getLogger("builder")
 
 @click.command()
 @click.option("--module", "-m", multiple=True, help="Module to include (repeatable)")
+@click.option("--all-modules", "-A", is_flag=True, help="Include all built-in gate and FTL modules")
 @click.option("--from-modules-file", "-f", default=None, help="Read module names from file (one per line, e.g. .ftl2-modules.txt)")
 @click.option("--module-dir", "-M", multiple=True, help="Module search directory (repeatable)")
 @click.option("--requirements", "-r", multiple=True, help="Requirements file (repeatable)")
 @click.option("--interpreter", "-I", default="/usr/bin/python3", help="Target Python interpreter")
+@click.option("--output", "-o", default=None, type=click.Path(), help="Copy built gate to this path")
 @click.option("--cache-dir", "-c", default="~/.ftl", help="Cache directory for built gates")
 @click.option("--verbose", "-v", is_flag=True, help="Verbose logging")
 @click.option("--debug", "-d", is_flag=True, help="Debug logging")
 def main(
     module: tuple[str, ...],
+    all_modules: bool,
     from_modules_file: str | None,
     module_dir: tuple[str, ...],
     requirements: tuple[str, ...],
     interpreter: str,
+    output: str | None,
     cache_dir: str,
     verbose: bool,
     debug: bool,
@@ -75,8 +82,18 @@ def main(
             modules.extend(file_modules)
             click.echo(f"Loaded {len(file_modules)} modules from {from_modules_file}")
 
+    if all_modules:
+        builtin_modules_dir = Path(__file__).parent / "modules"
+        for p in sorted(builtin_modules_dir.glob("*.py")):
+            if not p.name.startswith("_"):
+                modules.append(p.stem)
+        from ftl2.ftl_modules.executor import _FTL_MODULE_FILES
+        for name in _FTL_MODULE_FILES:
+            modules.append(name)
+        click.echo(f"Auto-discovered {len(modules)} modules (--all-modules)")
+
     if not modules:
-        raise click.ClickException("No modules specified. Use -m or -f to specify modules.")
+        raise click.ClickException("No modules specified. Use -m, -f, or --all-modules.")
 
     # Deduplicate while preserving order
     seen: set[str] = set()
@@ -112,7 +129,14 @@ def main(
     builder = GateBuilder(cache_dir=cache_dir)
     gate_path, gate_hash = builder.build(config)
 
-    click.echo(f"Gate: {gate_path}")
+    if output:
+        import shutil
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(gate_path, output_path)
+        click.echo(f"Gate: {output_path}")
+    else:
+        click.echo(f"Gate: {gate_path}")
     click.echo(f"Hash: {gate_hash}")
 
 

--- a/src/ftl2/gate.py
+++ b/src/ftl2/gate.py
@@ -347,7 +347,7 @@ class GateBuilder:
                         logger.debug(f"Installed FTL module {module} to {ftl_dir}")
                         continue
                 except Exception as ftl_err:
-                    logger.warning(f"FTL module {module} found in registry but failed to load: {ftl_err}")
+                    logger.warning(f"Failed to load FTL module {module}: {ftl_err}")
                     continue
                 # Neither Ansible nor FTL — skip it
                 logger.debug(f"Skipping {module}: not found as Ansible or FTL module ({e})")

--- a/src/ftl2/gate.py
+++ b/src/ftl2/gate.py
@@ -346,8 +346,9 @@ class GateBuilder:
                         (ftl_dir / f"{module}.py").write_bytes(ftl_source)
                         logger.debug(f"Installed FTL module {module} to {ftl_dir}")
                         continue
-                except Exception:
-                    pass
+                except Exception as ftl_err:
+                    logger.warning(f"FTL module {module} found in registry but failed to load: {ftl_err}")
+                    continue
                 # Neither Ansible nor FTL — skip it
                 logger.debug(f"Skipping {module}: not found as Ansible or FTL module ({e})")
                 continue


### PR DESCRIPTION
## Summary
- Adds `--all-modules` / `-A` flag to auto-discover all built-in gate and FTL modules for baking into the gate `.pyz`
- Adds `--output` / `-o` flag to copy the built gate to a specific path (useful for container builds / Dockerfiles)
- Improves error handling when a registered FTL module source file is missing — logs a warning instead of silently skipping

## Test plan
- [ ] `ftl-gate-builder --all-modules -o /tmp/gate.pyz -v` builds successfully with 18 modules
- [ ] Inspect archive contents to verify gate and FTL modules are present
- [ ] `pytest tests/test_gate.py` — all 32 tests pass
- [ ] `-o` flag creates the output file at the specified path
- [ ] `--all-modules` combined with `-m extra` includes both auto-discovered and explicit modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)